### PR TITLE
feat(ekf2): add thrust-based baro compensation and fix ground effect

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -205,6 +205,17 @@ void Ekf::stopBaroHgtFusion()
 #if defined(CONFIG_EKF2_BARO_COMPENSATION)
 float Ekf::compensateBaroForDynamicPressure(const imuSample &imu_sample, const float baro_alt_uncompensated) const
 {
+	float baro_alt = baro_alt_uncompensated;
+
+	// Propwash-induced static pressure compensation for multirotor vehicles.
+	// Corrects for the pressure change at the baro sensor caused by rotor downwash,
+	// which is proportional to collective thrust magnitude.
+	if (!_control_status.flags.fixed_wing && (fabsf(_params.ekf2_pcoef_thr) > FLT_EPSILON)) {
+		const float thrust_magnitude = fabsf(_vehicle_thrust_z);
+		baro_alt += _params.ekf2_pcoef_thr * thrust_magnitude;
+	}
+
+	// Airspeed-induced static pressure position error compensation
 	if (_control_status.flags.wind && isLocalHorizontalPositionValid()) {
 		// calculate static pressure error = Pmeas - Ptruth
 		// model position error sensitivity as a body fixed ellipse with a different scale in the positive and
@@ -231,10 +242,9 @@ float Ekf::compensateBaroForDynamicPressure(const imuSample &imu_sample, const f
 		const float pstatic_err = 0.5f * _air_density * (airspeed_squared.dot(K_pstatic_coef));
 
 		// correct baro measurement using pressure error estimate and assuming sea level gravity
-		return baro_alt_uncompensated + pstatic_err / (_air_density * CONSTANTS_ONE_G);
+		baro_alt += pstatic_err / (_air_density * CONSTANTS_ONE_G);
 	}
 
-	// otherwise return the uncorrected baro measurement
-	return baro_alt_uncompensated;
+	return baro_alt;
 }
 #endif // CONFIG_EKF2_BARO_COMPENSATION

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -323,6 +323,8 @@ struct parameters {
 	float ekf2_pcoef_yn{0.0f};    // (-)
 	float ekf2_pcoef_z{0.0f};     // (-)
 
+	float ekf2_pcoef_thr{0.0f};  // propwash baro altitude correction per unit thrust (m)
+
 	// upper limit on airspeed used for correction  (m/s**2)
 	float ekf2_aspd_max{20.0f};
 # endif // CONFIG_EKF2_BARO_COMPENSATION

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -211,6 +211,11 @@ public:
 	// set air density used by the multi-rotor specific drag force fusion
 	void set_air_density(float air_density) { _air_density = air_density; }
 
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	// set collective thrust magnitude for propwash baro compensation
+	void set_vehicle_thrust_z(float thrust_z) { _vehicle_thrust_z = thrust_z; }
+#endif // CONFIG_EKF2_BARO_COMPENSATION
+
 	bool isOnlyActiveSourceOfHorizontalAiding(bool aiding_flag) const;
 	bool isOnlyActiveSourceOfHorizontalPositionAiding(bool aiding_flag) const;
 	bool isOnlyActiveSourceOfHorizontalVelocityAiding(bool aiding_flag) const;
@@ -385,6 +390,10 @@ protected:
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 
 	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};		// air density (kg/m**3)
+
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	float _vehicle_thrust_z {0.f};		// collective thrust setpoint magnitude for propwash baro compensation
+#endif // CONFIG_EKF2_BARO_COMPENSATION
 
 	bool _imu_updated{false};      // true if the ekf should update (completed downsampling process)
 	bool _initialised{false};      // true if the ekf interface instance (data buffering) is initialized

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -109,6 +109,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_pcoef_yp(_params->ekf2_pcoef_yp),
 	_param_ekf2_pcoef_yn(_params->ekf2_pcoef_yn),
 	_param_ekf2_pcoef_z(_params->ekf2_pcoef_z),
+	_param_ekf2_pcoef_thr(_params->ekf2_pcoef_thr),
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 #if defined(CONFIG_EKF2_AIRSPEED)
@@ -2178,6 +2179,15 @@ void EKF2::UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps)
 		}
 
 		_ekf.set_air_density(airdata.rho);
+
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
+		vehicle_thrust_setpoint_s thrust_sp;
+
+		if (_vehicle_thrust_setpoint_sub.copy(&thrust_sp)) {
+			_ekf.set_vehicle_thrust_z(thrust_sp.xyz[2]);
+		}
+
+#endif // CONFIG_EKF2_BARO_COMPENSATION
 
 		_ekf.setBaroData(baroSample{airdata.timestamp_sample, airdata.baro_alt_meter, reset});
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -86,6 +86,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/yaw_estimator_status.h>
 
 #if defined(CONFIG_EKF2_AIRSPEED)
@@ -357,6 +358,10 @@ private:
 
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 
+# if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	uORB::Subscription _vehicle_thrust_setpoint_sub {ORB_ID(vehicle_thrust_setpoint)};
+# endif // CONFIG_EKF2_BARO_COMPENSATION
+
 	uORB::PublicationMulti<estimator_bias_s> _estimator_baro_bias_pub{ORB_ID(estimator_baro_bias)};
 	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_baro_hgt_pub {ORB_ID(estimator_aid_src_baro_hgt)};
 #endif // CONFIG_EKF2_BAROMETER
@@ -552,6 +557,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_PCOEF_YP>) _param_ekf2_pcoef_yp,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_YN>) _param_ekf2_pcoef_yn,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_Z>) _param_ekf2_pcoef_z,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_THR>) _param_ekf2_pcoef_thr,
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 

--- a/src/modules/ekf2/params_barometer.yaml
+++ b/src/modules/ekf2/params_barometer.yaml
@@ -119,6 +119,20 @@ parameters:
       min: -0.5
       max: 0.5
       decimal: 2
+    EKF2_PCOEF_THR:
+      description:
+        short: Static pressure position error coefficient for rotor thrust
+        long: Baro altitude correction per unit of normalized collective thrust [0, 1].
+          Compensates for propwash-induced static pressure changes at the baro
+          sensor on multirotor vehicles. Positive values correct for baro reading
+          too high during thrust (pressure decrease at sensor). Set to 0 to disable.
+          Not applied in fixed-wing mode.
+      type: float
+      default: 0.0
+      min: -50.0
+      max: 50.0
+      unit: m
+      decimal: 1
     EKF2_ASPD_MAX:
       description:
         short: Maximum airspeed used for baro static pressure compensation


### PR DESCRIPTION
## Summary

- Add `EKF2_PCOEF_THR` parameter for propwash-induced static pressure compensation on multirotors. Corrects baro altitude proportionally to collective thrust magnitude, addressing the dominant source of baro error in hover (propeller downwash creating a pressure change at the sensor).
- Replace the one-sided baro innovation deadzone for ground effect with symmetric observation variance inflation. The old deadzone only clipped negative innovations, failing for the majority of real-world frames where prop wash causes pressure decrease (positive innovations). The variance inflation is applied before `updateVerticalPositionAidStatus()` so the innovation variance, test ratio, Kalman gain, and logged diagnostics are all consistent.
- Raise `EKF2_GND_MAX_HGT` default from 0.5 m to 2.0 m and max from 5 to 10 m so ground effect protection covers realistic heights.

## Design

Four complementary mechanisms now address baro errors:

| Mechanism | What it handles | When active |
|---|---|---|
| `EKF2_PCOEF_{X,Y,Z}` | Airspeed-induced pressure errors | Wind estimate valid |
| `EKF2_PCOEF_THR` | Propwash-induced pressure errors | Non-fixed-wing, thrust > 0 |
| `EKF2_GND_EFF_DZ` | Increased uncertainty near ground | Ground effect flag set |
| Baro bias estimator | Slowly varying residual offset | Always |

`PCOEF_THR` is distinct from `PCOEF_Z` — they model different physics. `PCOEF_Z` corrects for pressure errors from vehicle airspeed (Bernoulli, requires wind estimate). `PCOEF_THR` corrects for propwash at the sensor (scales with thrust, works standalone). In hover with no wind, `PCOEF_Z` sees zero airspeed while `PCOEF_THR` provides the needed correction.

The inflated `measurement_var` also flows into the baro bias estimator, making it less aggressive during ground effect — preventing it from chasing propwash transients.

## Motivation

Flight log analysis shows baro reading +8 m too high during hover at 0.7 m AGL due to propwash pressure drop (~150 Pa). The existing ground effect deadzone never activates (`EKF2_GND_MAX_HGT` too low, `in_ground_effect` false), and even if it did, it only handles negative innovations. There is currently no mechanism in PX4 to compensate for thrust-correlated baro pressure errors.

## Test plan

- [ ] SITL: verify `EKF2_PCOEF_THR = 0` (default) produces identical behavior to baseline
- [ ] SITL: verify non-zero `EKF2_PCOEF_THR` applies correction proportional to thrust
- [ ] Bench test: hover with `EKF2_PCOEF_THR` calibrated, compare baro height error vs GPS
- [ ] Verify fixed-wing guard: correction must not apply when `fixed_wing` flag is set
- [ ] Verify ground effect variance inflation does not cause filter divergence
- [ ] EKF2 unit tests pass (basics, height_fusion, airspeed)