### PR TITLE
fix(ekf2): replace baro ground effect deadzone with variance inflation

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -57,7 +57,13 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 		const float measurement = baro_sample.hgt;
 #endif
 
-		const float measurement_var = sq(_params.ekf2_baro_noise);
+		float measurement_var = sq(_params.ekf2_baro_noise);
+
+		// When near the ground, rotor wash causes additional baro pressure disturbances.
+		// Inflate the observation variance to reduce baro authority during ground effect.
+		if (_control_status.flags.gnd_effect && (_params.ekf2_baro_ge_ni > 0.f)) {
+			measurement_var += sq(_params.ekf2_baro_ge_ni);
+		}
 
 		const bool measurement_valid = PX4_ISFINITE(measurement) && PX4_ISFINITE(measurement_var);
 
@@ -84,23 +90,6 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 						-(measurement - bias_est.getBias()),      // observation
 						measurement_var + bias_est.getBiasVar(),  // observation variance
 						math::max(_params.ekf2_baro_gate, 1.f)); // innovation gate
-
-		// Compensate for positive static pressure transients (negative vertical position innovations)
-		// caused by rotor wash ground interaction by applying a temporary deadzone to baro innovations.
-		if (_control_status.flags.gnd_effect && (_params.ekf2_gnd_eff_dz > 0.f)) {
-
-			const float deadzone_start = 0.0f;
-			const float deadzone_end = deadzone_start + _params.ekf2_gnd_eff_dz;
-
-			if (aid_src.innovation < -deadzone_start) {
-				if (aid_src.innovation <= -deadzone_end) {
-					aid_src.innovation += deadzone_end;
-
-				} else {
-					aid_src.innovation = -deadzone_start;
-				}
-			}
-		}
 
 		// update the bias estimator before updating the main filter but after
 		// using its current state to compute the vertical position innovation

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -312,8 +312,8 @@ struct parameters {
 	float baro_bias_nsd{0.13f};             ///< process noise for barometric height bias estimation (m/s/sqrt(Hz))
 	float ekf2_baro_gate{5.0f};             ///< barometric and GPS height innovation consistency gate size (STD)
 
-	float ekf2_gnd_eff_dz{5.0f};            ///< Size of deadzone applied to negative baro innovations when ground effect compensation is active (m)
-	float ekf2_gnd_max_hgt{0.5f};           ///< Height above ground at which baro ground effect becomes insignificant (m)
+	float ekf2_baro_ge_ni{4.0f};            ///< Baro noise inflation (std dev) when ground effect is active (m)
+	float ekf2_baro_ge_hgt{1.0f};           ///< Height above ground at which baro ground effect becomes insignificant (m)
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
 	// static barometer pressure position error coefficient along body axes

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -61,7 +61,8 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 			set_in_transition(system_flags_delayed.in_transition);
 
 			if (system_flags_delayed.gnd_effect) {
-				set_gnd_effect();
+				_control_status.flags.gnd_effect = true;
+				_time_last_gnd_effect_on = _time_delayed_us;
 			}
 
 			set_constant_pos(system_flags_delayed.constant_pos);

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -945,21 +945,46 @@ float Ekf::getTiltVariance() const
 void Ekf::updateGroundEffect()
 {
 	if (_control_status.flags.in_air && !_control_status.flags.fixed_wing) {
+
+		bool height_above_ground_known = false;
+		bool below_gnd_effect_hgt = false;
+
 #if defined(CONFIG_EKF2_TERRAIN)
 
 		if (isTerrainEstimateValid()) {
-			// automatically set ground effect if terrain is valid
-			float height = getHagl();
-			_control_status.flags.gnd_effect = (height < _params.ekf2_gnd_max_hgt);
+			height_above_ground_known = true;
+			below_gnd_effect_hgt = (getHagl() < _params.ekf2_baro_ge_hgt);
+		}
 
-		} else
 #endif // CONFIG_EKF2_TERRAIN
-			if (_control_status.flags.gnd_effect) {
-				// Turn off ground effect compensation if it times out
-				if (isTimedOut(_time_last_gnd_effect_on, GNDEFFECT_TIMEOUT)) {
-					_control_status.flags.gnd_effect = false;
-				}
+
+#if defined(CONFIG_EKF2_RANGE_FINDER)
+
+		// Fall back to raw range sensor when terrain estimation is not active
+		// (e.g. EKF2_RNG_CTRL disabled). Range data is still buffered and
+		// quality-checked regardless of fusion state.
+		if (!height_above_ground_known
+		    && _range_sensor.isDataHealthy()
+		    && isRecent(_time_last_range_buffer_push, 1'000'000)) {
+			height_above_ground_known = true;
+			below_gnd_effect_hgt = (_range_sensor.getDistBottom() < _params.ekf2_baro_ge_hgt);
+		}
+
+#endif // CONFIG_EKF2_RANGE_FINDER
+
+		if (height_above_ground_known) {
+			_control_status.flags.gnd_effect = below_gnd_effect_hgt;
+
+			if (below_gnd_effect_hgt) {
+				_time_last_gnd_effect_on = _time_delayed_us;
 			}
+
+		} else if (_control_status.flags.gnd_effect) {
+			// No height source available — preserve land detector flag with timeout
+			if (isTimedOut(_time_last_gnd_effect_on, GNDEFFECT_TIMEOUT)) {
+				_control_status.flags.gnd_effect = false;
+			}
+		}
 
 	} else {
 		_control_status.flags.gnd_effect = false;

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -199,15 +199,6 @@ public:
 
 	void set_in_transition(bool in_transition) { _control_status.flags.in_transition = in_transition; }
 
-	// set flag if static pressure rise due to ground effect is expected
-	// use _params.ekf2_gnd_eff_dz to adjust for expected rise in static pressure
-	// flag will clear after GNDEFFECT_TIMEOUT uSec
-	void set_gnd_effect()
-	{
-		_control_status.flags.gnd_effect = true;
-		_time_last_gnd_effect_on = _time_delayed_us;
-	}
-
 	// set air density used by the multi-rotor specific drag force fusion
 	void set_air_density(float air_density) { _air_density = air_density; }
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -100,8 +100,8 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_baro_delay(_params->ekf2_baro_delay),
 	_param_ekf2_baro_noise(_params->ekf2_baro_noise),
 	_param_ekf2_baro_gate(_params->ekf2_baro_gate),
-	_param_ekf2_gnd_eff_dz(_params->ekf2_gnd_eff_dz),
-	_param_ekf2_gnd_max_hgt(_params->ekf2_gnd_max_hgt),
+	_param_ekf2_baro_ge_ni(_params->ekf2_baro_ge_ni),
+	_param_ekf2_baro_ge_hgt(_params->ekf2_baro_ge_hgt),
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
 	_param_ekf2_aspd_max(_params->ekf2_aspd_max),
 	_param_ekf2_pcoef_xp(_params->ekf2_pcoef_xp),

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -541,8 +541,8 @@ private:
 		(ParamExtFloat<px4::params::EKF2_BARO_DELAY>) _param_ekf2_baro_delay,
 		(ParamExtFloat<px4::params::EKF2_BARO_NOISE>) _param_ekf2_baro_noise,
 		(ParamExtFloat<px4::params::EKF2_BARO_GATE>) _param_ekf2_baro_gate,
-		(ParamExtFloat<px4::params::EKF2_GND_EFF_DZ>) _param_ekf2_gnd_eff_dz,
-		(ParamExtFloat<px4::params::EKF2_GND_MAX_HGT>) _param_ekf2_gnd_max_hgt,
+		(ParamExtFloat<px4::params::EKF2_BARO_GE_NI>) _param_ekf2_baro_ge_ni,
+		(ParamExtFloat<px4::params::EKF2_BARO_GE_HGT>) _param_ekf2_baro_ge_hgt,
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
 		// Corrections for static pressure position error where Ps_error = Ps_meas - Ps_truth

--- a/src/modules/ekf2/params_barometer.yaml
+++ b/src/modules/ekf2/params_barometer.yaml
@@ -39,26 +39,28 @@ parameters:
       max: 15.0
       unit: m
       decimal: 2
-    EKF2_GND_EFF_DZ:
+    EKF2_BARO_GE_NI:
       description:
-        short: Baro deadzone range for height fusion
-        long: Sets the value of deadzone applied to negative baro innovations. Deadzone
-          is enabled when EKF2_GND_EFF_DZ > 0.
+        short: Baro ground effect noise inflation
+        long: Additional baro measurement noise (standard deviation) applied when
+          ground effect is active. Inflates the observation variance to reduce
+          baro authority near the ground. Set to 0 to disable.
       type: float
       default: 4.0
       min: 0.0
-      max: 10.0
+      max: 40.0
       unit: m
       decimal: 1
-    EKF2_GND_MAX_HGT:
+    EKF2_BARO_GE_HGT:
       description:
         short: Height above ground level for ground effect zone
-        long: Sets the maximum distance to the ground level where negative baro innovations
-          are expected.
+        long: Sets the maximum distance to the ground level where baro ground
+          effect compensation is active. Uses terrain estimate or raw range
+          sensor data when available.
       type: float
-      default: 0.5
+      default: 1.0
       min: 0.0
-      max: 5.0
+      max: 10.0
       unit: m
       decimal: 1
     EKF2_PCOEF_XP:

--- a/src/modules/ekf2/test/test_EKF_height_fusion.cpp
+++ b/src/modules/ekf2/test/test_EKF_height_fusion.cpp
@@ -59,6 +59,7 @@ public:
 	void SetUp() override
 	{
 		_ekf->init(0);
+		_ekf->getParamHandle()->ekf2_baro_ge_ni = 0.f; // disable ground effect for height fusion tests
 		_ekf_wrapper.disableBaroHeightFusion();
 		_ekf_wrapper.disableRangeHeightFusion();
 		_sensor_simulator.runSeconds(0.1);


### PR DESCRIPTION
## Summary

- Replace the one-sided baro innovation deadzone for ground effect with symmetric observation variance inflation. The old deadzone only clipped negative innovations, missing the majority of real-world cases where prop wash causes pressure decrease (positive innovations).
- The variance inflation is applied before `updateVerticalPositionAidStatus()` so the innovation variance, test ratio, Kalman gain, and logged diagnostics are all consistent with the inflated noise level. This also makes the baro bias estimator less aggressive during ground effect, preventing it from chasing propwash transients.
- Fix ground effect detection to use raw range sensor data as a fallback when terrain estimation is not active (e.g. `EKF2_RNG_CTRL` disabled). Previously required a valid terrain estimate (active range/flow fusion) or the land detector flag, making it effectively dead for many setups.
- New parameter names (`EKF2_BARO_GE_NI`, `EKF2_BARO_GE_HGT`) to avoid silently changing behavior for existing airframe files that set the old `EKF2_GND_EFF_DZ` / `EKF2_GND_MAX_HGT` params.
- Remove `set_gnd_effect()` helper, inline the member writes directly.

## New parameters

| New | Replaces | Default | Description |
|---|---|---|---|
| `EKF2_BARO_GE_NI` | `EKF2_GND_EFF_DZ` | 4.0 m | Baro noise std dev inflation during ground effect |
| `EKF2_BARO_GE_HGT` | `EKF2_GND_MAX_HGT` | 1.0 m | Height AGL below which ground effect is active |

## Ground effect detection priority

`updateGroundEffect()` now uses a fallback chain:
1. **Terrain estimate** — best source, filtered/fused HAGL (requires active terrain fusion)
2. **Raw range sensor** — fallback when terrain fusion is off but rangefinder data is healthy
3. **Land detector flag** — final fallback with 10s timeout (for airframes without a rangefinder)

## Test plan

- [ ] SITL: verify default behavior with new params
- [ ] Verify ground effect activates with rangefinder when EKF2_RNG_CTRL = 0
- [ ] Verify ground effect variance inflation does not cause filter divergence
- [ ] EKF2 unit tests pass
- [ ] Existing airframes with EKF2_GND_EFF_DZ set are unaffected (old param ignored, new defaults apply)