### PR TITLE
feat(sensors): add accelerometer FFT and dynamic notch filtering

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -345,6 +345,11 @@ then
 	gyro_fft start
 fi
 
+if param compare -s IMU_ACC_FFT_EN 1
+then
+	accel_fft start
+fi
+
 if param compare -s IMU_GYRO_CAL_EN 1
 then
 	gyro_calibration start

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -582,6 +582,11 @@ else
 		gyro_fft start
 	fi
 
+	if param compare -s IMU_ACC_FFT_EN 1
+	then
+		accel_fft start
+	fi
+
 	if param compare -s IMU_GYRO_CAL_EN 1
 	then
 		gyro_calibration start

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -194,6 +194,7 @@ set(msg_files
 	RtlTimeEstimate.msg
 	SatelliteInfo.msg
 	SensorAccel.msg
+	SensorAccelFft.msg
 	SensorAccelFifo.msg
 	SensorBaro.msg
 	SensorCombined.msg

--- a/msg/SensorAccelFft.msg
+++ b/msg/SensorAccelFft.msg
@@ -1,0 +1,15 @@
+uint64 timestamp          # time since system start (microseconds)
+uint64 timestamp_sample
+
+uint32 device_id          # unique device ID for the sensor that does not change between power cycles
+
+float32 sensor_sample_rate_hz
+float32 resolution_hz
+
+float32[3] peak_frequencies_x # x axis peak frequencies
+float32[3] peak_frequencies_y # y axis peak frequencies
+float32[3] peak_frequencies_z # z axis peak frequencies
+
+float32[3] peak_snr_x # x axis peak SNR
+float32[3] peak_snr_y # y axis peak SNR
+float32[3] peak_snr_z # z axis peak SNR

--- a/msg/SensorAccelFifo.msg
+++ b/msg/SensorAccelFifo.msg
@@ -11,3 +11,5 @@ uint8 samples             # number of valid samples
 int16[32] x               # acceleration in the FRD board frame X-axis in m/s^2
 int16[32] y               # acceleration in the FRD board frame Y-axis in m/s^2
 int16[32] z               # acceleration in the FRD board frame Z-axis in m/s^2
+
+uint8 ORB_QUEUE_LENGTH = 4

--- a/src/modules/accel_fft/AccelFFT.cpp
+++ b/src/modules/accel_fft/AccelFFT.cpp
@@ -1,0 +1,711 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "AccelFFT.hpp"
+
+#include <drivers/drv_hrt.h>
+#include <mathlib/math/Limits.hpp>
+#include <mathlib/math/Functions.hpp>
+
+using namespace matrix;
+
+ModuleBase::Descriptor AccelFFT::desc{task_spawn, custom_command, print_usage};
+
+AccelFFT::AccelFFT() :
+	ModuleParams(nullptr),
+	ScheduledWorkItem(MODULE_NAME, px4::wq_configurations::hp_default)
+{
+	for (int i = 0; i < MAX_NUM_PEAKS; i++) {
+		_sensor_accel_fft.peak_frequencies_x[i] = NAN;
+		_sensor_accel_fft.peak_frequencies_y[i] = NAN;
+		_sensor_accel_fft.peak_frequencies_z[i] = NAN;
+	}
+
+	_sensor_accel_fft_pub.advertise();
+}
+
+AccelFFT::~AccelFFT()
+{
+	perf_free(_cycle_perf);
+	perf_free(_cycle_interval_perf);
+	perf_free(_fft_perf);
+	perf_free(_accel_generation_gap_perf);
+	perf_free(_accel_fifo_generation_gap_perf);
+
+	delete[] _accel_data_buffer_x;
+	delete[] _accel_data_buffer_y;
+	delete[] _accel_data_buffer_z;
+	delete[] _hanning_window;
+	delete[] _fft_input_buffer;
+	delete[] _fft_outupt_buffer;
+	delete[] _peak_magnitudes_all;
+}
+
+bool AccelFFT::init()
+{
+	bool buffers_allocated = false;
+
+	// arm_rfft_init_q15(&_rfft_q15, _imu_accel_fft_len, 0, 1) manually inlined to save flash
+	_rfft_q15.pTwiddleAReal = (q15_t *) realCoefAQ15;
+	_rfft_q15.pTwiddleBReal = (q15_t *) realCoefBQ15;
+	_rfft_q15.ifftFlagR = 0;
+	_rfft_q15.bitReverseFlagR = 1;
+
+	switch (_param_imu_acc_fft_len.get()) {
+	case 256:
+		buffers_allocated = AllocateBuffers<256>();
+		_rfft_q15.fftLenReal = 256;
+		_rfft_q15.twidCoefRModifier = 32U;
+		_rfft_q15.pCfft = &arm_cfft_sR_q15_len128;
+		break;
+
+	case 512:
+		buffers_allocated = AllocateBuffers<512>();
+		_rfft_q15.fftLenReal = 512;
+		_rfft_q15.twidCoefRModifier = 16U;
+		_rfft_q15.pCfft = &arm_cfft_sR_q15_len256;
+		break;
+
+	case 1024:
+		buffers_allocated = AllocateBuffers<1024>();
+		_rfft_q15.fftLenReal = 1024;
+		_rfft_q15.twidCoefRModifier = 8U;
+		_rfft_q15.pCfft = &arm_cfft_sR_q15_len512;
+		break;
+
+	default:
+		// otherwise default to 256
+		PX4_ERR("Invalid IMU_ACC_FFT_LEN=%" PRId32 ", resetting", _param_imu_acc_fft_len.get());
+		buffers_allocated = AllocateBuffers<256>();
+		_rfft_q15.fftLenReal = 256;
+		_rfft_q15.twidCoefRModifier = 32U;
+		_rfft_q15.pCfft = &arm_cfft_sR_q15_len128;
+		_param_imu_acc_fft_len.set(256);
+		_param_imu_acc_fft_len.commit();
+		break;
+	}
+
+	if (buffers_allocated) {
+		_imu_accel_fft_len = _param_imu_acc_fft_len.get();
+
+		// init Hanning window
+		for (int n = 0; n < _imu_accel_fft_len; n++) {
+			const float hanning_value = 0.5f * (1.f - cosf(2.f * M_PI_F * n / (_imu_accel_fft_len - 1)));
+			arm_float_to_q15(&hanning_value, &_hanning_window[n], 1);
+		}
+
+		if (!SensorSelectionUpdate(true)) {
+			ScheduleDelayed(500_ms);
+		}
+
+		return true;
+	}
+
+	PX4_ERR("failed to allocate buffers");
+	return false;
+}
+
+bool AccelFFT::SensorSelectionUpdate(bool force)
+{
+	if (_sensor_selection_sub.updated() || (_selected_sensor_device_id == 0) || force) {
+		sensor_selection_s sensor_selection{};
+		_sensor_selection_sub.copy(&sensor_selection);
+
+		if ((sensor_selection.accel_device_id != 0) && (_selected_sensor_device_id != sensor_selection.accel_device_id)) {
+			// prefer sensor_accel_fifo if available
+			for (uint8_t i = 0; i < MAX_SENSOR_COUNT; i++) {
+				uORB::SubscriptionData<sensor_accel_fifo_s> sensor_accel_fifo_sub{ORB_ID(sensor_accel_fifo), i};
+
+				if (sensor_accel_fifo_sub.get().device_id == sensor_selection.accel_device_id) {
+					if (_sensor_accel_fifo_sub.ChangeInstance(i) && _sensor_accel_fifo_sub.registerCallback()) {
+						_sensor_accel_sub.unregisterCallback();
+						_sensor_accel_fifo_sub.set_required_updates(sensor_accel_fifo_s::ORB_QUEUE_LENGTH / 2);
+						_selected_sensor_device_id = sensor_selection.accel_device_id;
+						_accel_fifo = true;
+
+						if (_accel_fifo_generation_gap_perf == nullptr) {
+							_accel_fifo_generation_gap_perf = perf_alloc(PC_COUNT, MODULE_NAME": accel FIFO data gap");
+						}
+
+						return true;
+					}
+				}
+			}
+
+			// otherwise use sensor_accel
+			for (uint8_t i = 0; i < MAX_SENSOR_COUNT; i++) {
+				uORB::SubscriptionData<sensor_accel_s> sensor_accel_sub{ORB_ID(sensor_accel), i};
+
+				if (sensor_accel_sub.get().device_id == sensor_selection.accel_device_id) {
+					if (_sensor_accel_sub.ChangeInstance(i) && _sensor_accel_sub.registerCallback()) {
+						_sensor_accel_fifo_sub.unregisterCallback();
+						_sensor_accel_sub.set_required_updates(sensor_accel_s::ORB_QUEUE_LENGTH / 2);
+						_selected_sensor_device_id = sensor_selection.accel_device_id;
+						_accel_fifo = false;
+
+						if (_accel_generation_gap_perf == nullptr) {
+							_accel_generation_gap_perf = perf_alloc(PC_COUNT, MODULE_NAME": accel data gap");
+						}
+
+						return true;
+					}
+				}
+			}
+
+			PX4_ERR("unable to find or subscribe to selected sensor (%" PRIu32 ")", sensor_selection.accel_device_id);
+		}
+	}
+
+	return false;
+}
+
+void AccelFFT::VehicleIMUStatusUpdate(bool force)
+{
+	if (_vehicle_imu_status_sub.updated() || force) {
+		vehicle_imu_status_s vehicle_imu_status;
+
+		if (_vehicle_imu_status_sub.copy(&vehicle_imu_status)) {
+			// find corresponding vehicle_imu_status instance if the device_id doesn't match
+			if (vehicle_imu_status.accel_device_id != _selected_sensor_device_id) {
+
+				for (uint8_t imu_status = 0; imu_status < MAX_SENSOR_COUNT; imu_status++) {
+					uORB::Subscription imu_status_sub{ORB_ID(vehicle_imu_status), imu_status};
+
+					if (imu_status_sub.copy(&vehicle_imu_status)) {
+						if (vehicle_imu_status.accel_device_id == _selected_sensor_device_id) {
+							_vehicle_imu_status_sub.ChangeInstance(imu_status);
+							break;
+						}
+					}
+				}
+			}
+
+			// update accel sample rate
+			if ((vehicle_imu_status.accel_device_id == _selected_sensor_device_id) && (vehicle_imu_status.accel_rate_hz > 0)) {
+				if (_accel_fifo) {
+					_accel_sample_rate_hz = vehicle_imu_status.accel_raw_rate_hz;
+
+				} else {
+					_accel_sample_rate_hz = vehicle_imu_status.accel_rate_hz;
+				}
+
+				return;
+			}
+		}
+	}
+}
+
+// helper function used for frequency estimation
+static inline float tau(float x)
+{
+	// tau(x) = 1/4 * log(3x^2 + 6x + 1) – sqrt(6)/24 * log((x + 1 – sqrt(2/3))  /  (x + 1 + sqrt(2/3)))
+	float p1 = logf(3.f * powf(x, 2.f) + 6.f * x + 1.f);
+	float part1 = x + 1.f - sqrtf(2.f / 3.f);
+	float part2 = x + 1.f + sqrtf(2.f / 3.f);
+	float p2 = logf(part1 / part2);
+	return (0.25f * p1 - sqrtf(6.f) / 24.f * p2);
+}
+
+float AccelFFT::EstimatePeakFrequencyBin(q15_t fft[], int peak_index)
+{
+	if (peak_index >= 2) {
+		// find peak location using Quinn's Second Estimator (2020-06-14: http://dspguru.com/dsp/howtos/how-to-interpolate-fft-peak/)
+		float real[3] { (float)fft[peak_index - 2], (float)fft[peak_index], (float)fft[peak_index + 2]     };
+		float imag[3] { (float)fft[peak_index - 2 + 1], (float)fft[peak_index + 1], (float)fft[peak_index + 2 + 1] };
+
+		static constexpr int k = 1;
+
+		const float divider = (real[k] * real[k] + imag[k] * imag[k]);
+
+		// ap = (X[k + 1].r * X[k].r + X[k+1].i * X[k].i) / (X[k].r * X[k].r + X[k].i * X[k].i)
+		float ap = (real[k + 1] * real[k] + imag[k + 1] * imag[k]) / divider;
+
+		// dp = -ap / (1 – ap)
+		float dp = -ap  / (1.f - ap);
+
+		// am = (X[k - 1].r * X[k].r + X[k – 1].i * X[k].i) / (X[k].r * X[k].r + X[k].i * X[k].i)
+		float am = (real[k - 1] * real[k] + imag[k - 1] * imag[k]) / divider;
+
+		// dm = am / (1 – am)
+		float dm = am / (1.f - am);
+
+		// d = (dp + dm) / 2 + tau(dp * dp) – tau(dm * dm)
+		float d = (dp + dm) / 2.f + tau(dp * dp) - tau(dm * dm);
+
+		// k' = k + d
+		return peak_index + 2.f * d;
+	}
+
+	return NAN;
+}
+
+void AccelFFT::Run()
+{
+	if (should_exit()) {
+		_sensor_accel_sub.unregisterCallback();
+		_sensor_accel_fifo_sub.unregisterCallback();
+		exit_and_cleanup(desc);
+		return;
+	}
+
+	// backup schedule
+	ScheduleDelayed(500_ms);
+
+	perf_begin(_cycle_perf);
+	perf_count(_cycle_interval_perf);
+
+	// Check if parameters have changed
+	if (_parameter_update_sub.updated()) {
+		// clear update
+		parameter_update_s param_update;
+		_parameter_update_sub.copy(&param_update);
+
+		updateParams();
+	}
+
+	const bool selection_updated = SensorSelectionUpdate();
+	VehicleIMUStatusUpdate(selection_updated);
+
+	// reset
+	_fft_updated = false;
+
+	if (_accel_fifo) {
+		// run on sensor accel fifo updates
+		sensor_accel_fifo_s sensor_accel_fifo;
+
+		while (_sensor_accel_fifo_sub.update(&sensor_accel_fifo)) {
+			if (_sensor_accel_fifo_sub.get_last_generation() != _accel_last_generation + 1) {
+				// force reset if we've missed a sample
+				_fft_buffer_index[0] = 0;
+				_fft_buffer_index[1] = 0;
+				_fft_buffer_index[2] = 0;
+
+				perf_count(_accel_fifo_generation_gap_perf);
+			}
+
+			_accel_last_generation = _sensor_accel_fifo_sub.get_last_generation();
+
+			if (fabsf(sensor_accel_fifo.scale - _fifo_last_scale) > FLT_EPSILON) {
+				// force reset if scale has changed
+				_fft_buffer_index[0] = 0;
+				_fft_buffer_index[1] = 0;
+				_fft_buffer_index[2] = 0;
+
+				_fifo_last_scale = sensor_accel_fifo.scale;
+			}
+
+			int16_t *input[] {sensor_accel_fifo.x, sensor_accel_fifo.y, sensor_accel_fifo.z};
+			Update(sensor_accel_fifo.timestamp_sample, input, sensor_accel_fifo.samples);
+		}
+
+	} else {
+		// run on sensor accel updates
+		sensor_accel_s sensor_accel;
+
+		while (_sensor_accel_sub.update(&sensor_accel)) {
+			if (_sensor_accel_sub.get_last_generation() != _accel_last_generation + 1) {
+				// force reset if we've missed a sample
+				_fft_buffer_index[0] = 0;
+				_fft_buffer_index[1] = 0;
+				_fft_buffer_index[2] = 0;
+
+				perf_count(_accel_generation_gap_perf);
+			}
+
+			_accel_last_generation = _sensor_accel_sub.get_last_generation();
+
+			const float accel_scale = 1000.f; // arbitrary scaling float32 m/s^2 -> raw int16
+			int16_t accel_x[1] {(int16_t)roundf(sensor_accel.x * accel_scale)};
+			int16_t accel_y[1] {(int16_t)roundf(sensor_accel.y * accel_scale)};
+			int16_t accel_z[1] {(int16_t)roundf(sensor_accel.z * accel_scale)};
+
+			int16_t *input[] {accel_x, accel_y, accel_z};
+			Update(sensor_accel.timestamp_sample, input, 1);
+		}
+	}
+
+	if (_publish) {
+		Publish();
+		_publish = false;
+	}
+
+	perf_end(_cycle_perf);
+}
+
+void AccelFFT::Update(const hrt_abstime &timestamp_sample, int16_t *input[], uint8_t N)
+{
+	q15_t *accel_data_buffer[] {_accel_data_buffer_x, _accel_data_buffer_y, _accel_data_buffer_z};
+
+	for (int axis = 0; axis < 3; axis++) {
+		int &buffer_index = _fft_buffer_index[axis];
+
+		for (int n = 0; n < N; n++) {
+			if (buffer_index < _imu_accel_fft_len) {
+				// convert int16_t -> q15_t (scaling isn't relevant)
+				accel_data_buffer[axis][buffer_index] = input[axis][n] / 2;
+				buffer_index++;
+			}
+
+			// if we have enough samples begin processing, but only one FFT per cycle
+			if ((buffer_index >= _imu_accel_fft_len) && !_fft_updated) {
+				perf_begin(_fft_perf);
+
+				arm_mult_q15(accel_data_buffer[axis], _hanning_window, _fft_input_buffer, _imu_accel_fft_len);
+				arm_rfft_q15(&_rfft_q15, _fft_input_buffer, _fft_outupt_buffer);
+
+				_fft_updated = true;
+
+				FindPeaks(timestamp_sample, axis, _fft_outupt_buffer);
+
+				// reset
+				// shift buffer (3/4 overlap)
+				const int overlap_start = _imu_accel_fft_len / 4;
+				memmove(&accel_data_buffer[axis][0], &accel_data_buffer[axis][overlap_start], sizeof(q15_t) * overlap_start * 3);
+				buffer_index = overlap_start * 3;
+
+				perf_end(_fft_perf);
+			}
+		}
+	}
+}
+
+void AccelFFT::FindPeaks(const hrt_abstime &timestamp_sample, int axis, q15_t *fft_outupt_buffer)
+{
+	const float resolution_hz = _accel_sample_rate_hz / _imu_accel_fft_len;
+
+	// sum total energy across all used buckets for SNR
+	float bin_mag_sum = 0;
+
+	// FFT output buffer is ordered [real[0], imag[0], real[1], imag[1], real[2], imag[2] ... real[(N/2)-1], imag[(N/2)-1]
+	for (size_t fft_index = 2; fft_index < static_cast<size_t>(_imu_accel_fft_len); fft_index += 2) {
+
+		const float real = fft_outupt_buffer[fft_index];
+		const float imag = fft_outupt_buffer[fft_index + 1];
+
+		const float fft_magnitude = sqrtf(real * real + imag * imag);
+
+		size_t bin_index = fft_index / 2;
+
+		_peak_magnitudes_all[bin_index] = fft_magnitude;
+		bin_mag_sum += fft_magnitude;
+	}
+
+
+	// find raw peaks
+	uint16_t raw_peak_index[MAX_NUM_PEAKS] {};
+	float peak_magnitude[MAX_NUM_PEAKS] {};
+
+	for (int i = 0; i < MAX_NUM_PEAKS; i++) {
+
+		float largest_peak = 0;
+		int largest_peak_index = 0;
+
+		for (int bin_index = 1; bin_index < _imu_accel_fft_len / 2; bin_index++) {
+
+			const float freq_hz = bin_index * resolution_hz;
+
+			if ((_peak_magnitudes_all[bin_index] > largest_peak)
+			    && (freq_hz >= _param_imu_acc_fft_min.get())
+			    && (freq_hz <= _param_imu_acc_fft_max.get())) {
+
+				largest_peak = _peak_magnitudes_all[bin_index];
+				largest_peak_index = bin_index;
+			}
+		}
+
+		if (largest_peak_index > 1) {
+			raw_peak_index[i] = largest_peak_index;
+			peak_magnitude[i] = _peak_magnitudes_all[largest_peak_index];
+
+			// remove peak + sides (included in frequency estimate later)
+			_peak_magnitudes_all[largest_peak_index - 1] = 0;
+			_peak_magnitudes_all[largest_peak_index]     = 0;
+			_peak_magnitudes_all[largest_peak_index + 1] = 0;
+		}
+	}
+
+	// keep if peak has been previously seen and SNR > MIN_SNR
+	//   or
+	// peak has SNR > MIN_SNR_INITIAL
+	static constexpr float MIN_SNR = 1.f;
+
+	int num_peaks_found = 0;
+	float peak_frequencies[MAX_NUM_PEAKS] {};
+	float peak_snr[MAX_NUM_PEAKS] {};
+
+	float *peak_frequencies_publish[] { _sensor_accel_fft.peak_frequencies_x, _sensor_accel_fft.peak_frequencies_y, _sensor_accel_fft.peak_frequencies_z };
+
+	float peak_frequencies_prev[MAX_NUM_PEAKS];
+
+	for (int i = 0; i < MAX_NUM_PEAKS; i++) {
+		peak_frequencies_prev[i] = peak_frequencies_publish[axis][i];
+	}
+
+	for (int peak_new = 0; peak_new < MAX_NUM_PEAKS; peak_new++) {
+		if (raw_peak_index[peak_new] > 0) {
+
+			const float adjusted_bin = 0.5f * EstimatePeakFrequencyBin(fft_outupt_buffer, 2 * raw_peak_index[peak_new]);
+
+			if (PX4_ISFINITE(adjusted_bin)) {
+				const float freq_adjusted = resolution_hz * adjusted_bin;
+
+				const float snr = 10.f * log10f((_imu_accel_fft_len - 1) * peak_magnitude[peak_new] /
+								(bin_mag_sum - peak_magnitude[peak_new]));
+
+				if (PX4_ISFINITE(freq_adjusted)
+				    && (snr > MIN_SNR)
+				    && (freq_adjusted >= _param_imu_acc_fft_min.get())
+				    && (freq_adjusted <= _param_imu_acc_fft_max.get())) {
+
+					// only keep if we're already tracking this frequency or if the SNR is significant
+					for (int peak_prev = 0; peak_prev < MAX_NUM_PEAKS; peak_prev++) {
+						bool snr_acceptable = (snr > _param_imu_acc_fft_snr.get());
+						bool peak_close = (fabsf(freq_adjusted - peak_frequencies_prev[peak_prev]) < (resolution_hz * 0.25f));
+
+						if (snr_acceptable || peak_close) {
+							// keep
+							peak_frequencies[num_peaks_found] = freq_adjusted;
+							peak_snr[num_peaks_found] = snr;
+
+							// remove
+							if (peak_close) {
+								peak_frequencies_prev[peak_prev] = NAN;
+							}
+
+							num_peaks_found++;
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if (num_peaks_found > 0) {
+		UpdateOutput(timestamp_sample, axis, peak_frequencies, peak_snr, num_peaks_found);
+	}
+}
+
+void AccelFFT::UpdateOutput(const hrt_abstime &timestamp_sample, int axis, float peak_frequencies[MAX_NUM_PEAKS],
+			    float peak_snr[MAX_NUM_PEAKS], int num_peaks_found)
+{
+	float *peak_frequencies_publish[] { _sensor_accel_fft.peak_frequencies_x, _sensor_accel_fft.peak_frequencies_y, _sensor_accel_fft.peak_frequencies_z };
+	float *peak_snr_publish[]         { _sensor_accel_fft.peak_snr_x,         _sensor_accel_fft.peak_snr_y,         _sensor_accel_fft.peak_snr_z };
+
+	// new peak: r, old peak: c
+	float peak_frequencies_diff[MAX_NUM_PEAKS][MAX_NUM_PEAKS];
+
+	for (int peak_new = 0; peak_new < MAX_NUM_PEAKS; peak_new++) {
+		// compute distance to previous peaks
+		for (int peak_prev = 0; peak_prev < MAX_NUM_PEAKS; peak_prev++) {
+			if ((peak_frequencies[peak_new] > 0)
+			    && (peak_frequencies_publish[axis][peak_prev] > 0) && PX4_ISFINITE(peak_frequencies_publish[axis][peak_prev])
+			   ) {
+				peak_frequencies_diff[peak_new][peak_prev] = fabsf(peak_frequencies[peak_new] -
+						peak_frequencies_publish[axis][peak_prev]);
+
+			} else {
+				peak_frequencies_diff[peak_new][peak_prev] = INFINITY;
+			}
+		}
+	}
+
+	// go through peak_frequencies_diff and find smallest diff (closest peaks)
+	//  - copy new peak to old peak slot
+	//  - exclude new peak (row) and old peak (column) in search
+	//  - repeat
+	//
+	//  - finally copy unmatched peaks to empty slots
+	bool peak_new_copied[MAX_NUM_PEAKS] {};
+	bool peak_out_filled[MAX_NUM_PEAKS] {};
+	int peaks_copied = 0;
+
+	for (int new_peak = 0; new_peak < num_peaks_found; new_peak++) {
+
+		float smallest_diff = INFINITY;
+		int closest_new_peak = -1;
+		int closest_prev_peak = -1;
+
+		// find new peak with smallest difference to old peak
+		for (int peak_new = 0; peak_new < num_peaks_found; peak_new++) {
+			for (int peak_prev = 0; peak_prev < MAX_NUM_PEAKS; peak_prev++) {
+				if (!peak_new_copied[peak_new] && !peak_out_filled[peak_prev]
+				    && (peak_frequencies_diff[peak_new][peak_prev] < smallest_diff)) {
+
+					smallest_diff = peak_frequencies_diff[peak_new][peak_prev];
+					closest_new_peak = peak_new;
+					closest_prev_peak = peak_prev;
+				}
+			}
+		}
+
+		if (PX4_ISFINITE(smallest_diff) && (smallest_diff >= 0)) {
+			// smallest diff found, copy newly found peak into same slot previously published
+			float peak_frequency = _median_filter[axis][closest_prev_peak].apply(peak_frequencies[closest_new_peak]);
+
+			if (peak_frequency > 0) {
+				peak_frequencies_publish[axis][closest_prev_peak] = peak_frequency;
+				peak_snr_publish[axis][closest_prev_peak] = peak_snr[closest_new_peak];
+				peaks_copied++;
+
+				_last_update[axis][closest_prev_peak] = timestamp_sample;
+				_sensor_accel_fft.timestamp_sample = timestamp_sample;
+				_publish = true;
+
+				// clear
+				peak_frequencies[closest_new_peak] = NAN;
+				peak_frequencies_diff[closest_new_peak][closest_prev_peak] = NAN;
+				peak_new_copied[closest_new_peak] = true;
+				peak_out_filled[closest_prev_peak] = true;
+
+				if (peaks_copied == num_peaks_found) {
+					break;
+				}
+			}
+		}
+	}
+
+	// clear any stale entries
+	for (int peak_out = 0; peak_out < MAX_NUM_PEAKS; peak_out++) {
+		if (timestamp_sample - _last_update[axis][peak_out] > 100_ms) {
+			peak_frequencies_publish[axis][peak_out] = NAN;
+			peak_snr_publish[axis][peak_out] = NAN;
+
+			_last_update[axis][peak_out] = 0;
+		}
+	}
+
+	// copy any remaining new (unmatched) peaks to overwrite old or empty slots
+	if (peaks_copied != num_peaks_found) {
+		for (int peak_new = 0; peak_new < num_peaks_found; peak_new++) {
+			if (PX4_ISFINITE(peak_frequencies[peak_new]) && (peak_frequencies[peak_new] > 0)) {
+				int oldest_slot = -1;
+				hrt_abstime oldest = timestamp_sample;
+
+				// find oldest slot and replace with new peak frequency
+				for (int peak_prev = 0; peak_prev < MAX_NUM_PEAKS; peak_prev++) {
+					if (_last_update[axis][peak_prev] < oldest) {
+						oldest_slot = peak_prev;
+						oldest = _last_update[axis][peak_prev];
+					}
+				}
+
+				if (oldest_slot >= 0) {
+					// copy peak to output slot
+					float peak_frequency = _median_filter[axis][oldest_slot].apply(peak_frequencies[peak_new]);
+
+					if (peak_frequency > 0) {
+						peak_frequencies_publish[axis][oldest_slot] = peak_frequency;
+						peak_snr_publish[axis][oldest_slot] = peak_snr[peak_new];
+
+						_last_update[axis][oldest_slot] = timestamp_sample;
+						_sensor_accel_fft.timestamp_sample = timestamp_sample;
+						_publish = true;
+					}
+				}
+			}
+		}
+	}
+}
+
+void AccelFFT::Publish()
+{
+	_sensor_accel_fft.device_id = _selected_sensor_device_id;
+	_sensor_accel_fft.sensor_sample_rate_hz = _accel_sample_rate_hz;
+	_sensor_accel_fft.resolution_hz = _accel_sample_rate_hz / _imu_accel_fft_len;
+	_sensor_accel_fft.timestamp = hrt_absolute_time();
+	_sensor_accel_fft_pub.publish(_sensor_accel_fft);
+}
+
+int AccelFFT::task_spawn(int argc, char *argv[])
+{
+	AccelFFT *instance = new AccelFFT();
+
+	if (instance) {
+		desc.object.store(instance);
+		desc.task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	desc.object.store(nullptr);
+	desc.task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int AccelFFT::print_status()
+{
+	PX4_INFO("accel sample rate: %.3f Hz", (double)_accel_sample_rate_hz);
+	perf_print_counter(_cycle_perf);
+	perf_print_counter(_cycle_interval_perf);
+	perf_print_counter(_fft_perf);
+	perf_print_counter(_accel_generation_gap_perf);
+	perf_print_counter(_accel_fifo_generation_gap_perf);
+	return 0;
+}
+
+int AccelFFT::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int AccelFFT::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("accel_fft", "system");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int accel_fft_main(int argc, char *argv[])
+{
+	return ModuleBase::main(AccelFFT::desc, argc, argv);
+}

--- a/src/modules/accel_fft/AccelFFT.hpp
+++ b/src/modules/accel_fft/AccelFFT.hpp
@@ -1,0 +1,176 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef ACCEL_FFT_HPP
+#define ACCEL_FFT_HPP
+
+#include <lib/mathlib/math/filter/MedianFilter.hpp>
+#include <lib/matrix/matrix/math.hpp>
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/posix.h>
+#include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/PublicationMulti.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/sensor_accel.h>
+#include <uORB/topics/sensor_accel_fft.h>
+#include <uORB/topics/sensor_accel_fifo.h>
+#include <uORB/topics/sensor_selection.h>
+#include <uORB/topics/vehicle_imu_status.h>
+
+#include "arm_math.h"
+#include "arm_const_structs.h"
+
+using namespace time_literals;
+
+class AccelFFT : public ModuleBase, public ModuleParams, public px4::ScheduledWorkItem
+{
+public:
+	static Descriptor desc;
+
+	AccelFFT();
+	~AccelFFT() override;
+
+	/** @see ModuleBase */
+	static int task_spawn(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int custom_command(int argc, char *argv[]);
+
+	/** @see ModuleBase */
+	static int print_usage(const char *reason = nullptr);
+
+	/** @see ModuleBase::print_status() */
+	int print_status() override;
+
+	bool init();
+
+private:
+	static constexpr int MAX_SENSOR_COUNT = 4;
+
+	static constexpr int MAX_NUM_PEAKS = sizeof(sensor_accel_fft_s::peak_frequencies_x) / sizeof(
+			sensor_accel_fft_s::peak_frequencies_x[0]);
+
+	void Run() override;
+	inline void FindPeaks(const hrt_abstime &timestamp_sample, int axis, q15_t *fft_outupt_buffer);
+	inline float EstimatePeakFrequencyBin(q15_t fft[], int peak_index);
+	inline void Publish();
+	bool SensorSelectionUpdate(bool force = false);
+	void Update(const hrt_abstime &timestamp_sample, int16_t *input[], uint8_t N);
+	inline void UpdateOutput(const hrt_abstime &timestamp_sample, int axis, float peak_frequencies[MAX_NUM_PEAKS],
+				 float peak_snr[MAX_NUM_PEAKS], int num_peaks_found);
+	void VehicleIMUStatusUpdate(bool force = false);
+
+	template<size_t N>
+	bool AllocateBuffers()
+	{
+		_accel_data_buffer_x = new q15_t[N];
+		_accel_data_buffer_y = new q15_t[N];
+		_accel_data_buffer_z = new q15_t[N];
+		_hanning_window = new q15_t[N];
+		_fft_input_buffer = new q15_t[N];
+		_fft_outupt_buffer = new q15_t[N * 2];
+
+		_peak_magnitudes_all = new float[N];
+
+		return (_accel_data_buffer_x && _accel_data_buffer_y && _accel_data_buffer_z
+			&& _hanning_window
+			&& _fft_input_buffer
+			&& _fft_outupt_buffer
+			&& _peak_magnitudes_all);
+	}
+
+	uORB::Publication<sensor_accel_fft_s> _sensor_accel_fft_pub{ORB_ID(sensor_accel_fft)};
+
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+
+	uORB::Subscription _sensor_selection_sub{ORB_ID(sensor_selection)};
+	uORB::Subscription _vehicle_imu_status_sub{ORB_ID(vehicle_imu_status)};
+
+	uORB::SubscriptionCallbackWorkItem _sensor_accel_sub{this, ORB_ID(sensor_accel)};
+	uORB::SubscriptionCallbackWorkItem _sensor_accel_fifo_sub{this, ORB_ID(sensor_accel_fifo)};
+
+	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+	perf_counter_t _cycle_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": cycle interval")};
+	perf_counter_t _fft_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": FFT")};
+	perf_counter_t _accel_generation_gap_perf{nullptr};
+	perf_counter_t _accel_fifo_generation_gap_perf{nullptr};
+
+	uint32_t _selected_sensor_device_id{0};
+
+	bool _accel_fifo{false};
+
+	arm_rfft_instance_q15 _rfft_q15;
+
+	q15_t *_accel_data_buffer_x{nullptr};
+	q15_t *_accel_data_buffer_y{nullptr};
+	q15_t *_accel_data_buffer_z{nullptr};
+	q15_t *_hanning_window{nullptr};
+	q15_t *_fft_input_buffer{nullptr};
+	q15_t *_fft_outupt_buffer{nullptr};
+
+	float *_peak_magnitudes_all{nullptr};
+
+	float _accel_sample_rate_hz{4000}; // 4 kHz default
+
+	float _fifo_last_scale{0};
+
+	int _fft_buffer_index[3] {};
+
+	unsigned _accel_last_generation{0};
+
+	math::MedianFilter<float, 7> _median_filter[3][MAX_NUM_PEAKS] {};
+
+	sensor_accel_fft_s _sensor_accel_fft{};
+
+	hrt_abstime _last_update[3][MAX_NUM_PEAKS] {};
+
+	int32_t _imu_accel_fft_len{256};
+
+	bool _fft_updated{false};
+	bool _publish{false};
+
+	DEFINE_PARAMETERS(
+		(ParamInt<px4::params::IMU_ACC_FFT_LEN>) _param_imu_acc_fft_len,
+		(ParamFloat<px4::params::IMU_ACC_FFT_MIN>) _param_imu_acc_fft_min,
+		(ParamFloat<px4::params::IMU_ACC_FFT_MAX>) _param_imu_acc_fft_max,
+		(ParamFloat<px4::params::IMU_ACC_FFT_SNR>) _param_imu_acc_fft_snr
+	)
+};
+
+#endif // !ACCEL_FFT_HPP

--- a/src/modules/accel_fft/CMakeLists.txt
+++ b/src/modules/accel_fft/CMakeLists.txt
@@ -1,0 +1,84 @@
+############################################################################
+#
+#   Copyright (c) 2020-2022 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+set(CMSIS_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../gyro_fft/CMSIS_5)
+set(CMSIS_DSP ${CMSIS_ROOT}/CMSIS/DSP)
+
+if(${PX4_PLATFORM} MATCHES "NuttX")
+	add_compile_options(-DARM_MATH_DSP)
+endif()
+
+# Disable 32-bit assembly warnings on arm64 platforms (Apple Silicon, Linux aarch64).
+# CMSIS DSP contains ARM Cortex-M assembly that triggers clang warnings on 64-bit ARM.
+# This code is unused on POSIX platforms - only the C fallback implementations run.
+if(${PX4_PLATFORM} MATCHES "posix" AND ${CMAKE_HOST_SYSTEM_PROCESSOR} MATCHES "arm64|aarch64")
+	add_compile_options(-Wno-asm-operand-widths)
+endif()
+
+add_compile_options($<$<COMPILE_LANGUAGE:C>:-Wno-nested-externs>)
+
+px4_add_module(
+	MODULE modules__accel_fft
+	MAIN accel_fft
+	STACK_MAIN
+		4096
+	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
+		-DARM_ALL_FFT_TABLES
+		-DARM_MATH_LOOPUNROLL
+	INCLUDES
+		${CMSIS_ROOT}/CMSIS/Core/Include
+		${CMSIS_DSP}/Include
+	SRCS
+		AccelFFT.cpp
+		AccelFFT.hpp
+
+		${CMSIS_ROOT}/CMSIS/Core/Include/cmsis_compiler.h
+		${CMSIS_ROOT}/CMSIS/Core/Include/cmsis_gcc.h
+		${CMSIS_DSP}/Include/arm_common_tables.h
+		${CMSIS_DSP}/Include/arm_const_structs.h
+		${CMSIS_DSP}/Include/arm_math.h
+		${CMSIS_DSP}/Source/BasicMathFunctions/arm_mult_q15.c
+		${CMSIS_DSP}/Source/CommonTables/arm_common_tables.c
+		${CMSIS_DSP}/Source/CommonTables/arm_const_structs.c
+		${CMSIS_DSP}/Source/SupportFunctions/arm_float_to_q15.c
+		${CMSIS_DSP}/Source/TransformFunctions/arm_bitreversal2.c
+		${CMSIS_DSP}/Source/TransformFunctions/arm_cfft_q15.c
+		${CMSIS_DSP}/Source/TransformFunctions/arm_cfft_radix4_q15.c
+		${CMSIS_DSP}/Source/TransformFunctions/arm_rfft_init_q15.c
+		${CMSIS_DSP}/Source/TransformFunctions/arm_rfft_q15.c
+	MODULE_CONFIG
+		parameters.yaml
+	DEPENDS
+		px4_work_queue
+)

--- a/src/modules/accel_fft/Kconfig
+++ b/src/modules/accel_fft/Kconfig
@@ -1,0 +1,12 @@
+menuconfig MODULES_ACCEL_FFT
+	bool "accel_fft"
+	default n
+	---help---
+		Enable support for accel_fft
+
+menuconfig USER_ACCEL_FFT
+	bool "accel_fft running as userspace module"
+	default n
+	depends on BOARD_PROTECTED && MODULES_ACCEL_FFT
+	---help---
+		Put accel_fft in userspace memory

--- a/src/modules/accel_fft/parameters.yaml
+++ b/src/modules/accel_fft/parameters.yaml
@@ -1,0 +1,45 @@
+module_name: accel_fft
+parameters:
+- group: Sensors
+  definitions:
+    IMU_ACC_FFT_EN:
+      description:
+        short: IMU accel FFT enable
+      type: boolean
+      default: 0
+      reboot_required: true
+    IMU_ACC_FFT_MIN:
+      description:
+        short: IMU accel FFT minimum frequency
+      type: float
+      default: 30.0
+      min: 1
+      max: 1000
+      unit: Hz
+      reboot_required: true
+    IMU_ACC_FFT_MAX:
+      description:
+        short: IMU accel FFT maximum frequency
+      type: float
+      default: 150.0
+      min: 1
+      max: 1000
+      unit: Hz
+      reboot_required: true
+    IMU_ACC_FFT_LEN:
+      description:
+        short: IMU accel FFT length
+      type: enum
+      values:
+        256: '256'
+        512: '512'
+        1024: '1024'
+      default: 512
+      reboot_required: true
+    IMU_ACC_FFT_SNR:
+      description:
+        short: IMU accel FFT SNR
+      type: float
+      default: 10.0
+      min: 1
+      max: 30

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -122,6 +122,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic("sensor_airflow", 100);
 	add_topic("sensor_combined");
 	add_optional_topic("sensor_correction");
+	add_optional_topic("sensor_accel_fft", 50);
 	add_optional_topic("sensor_gyro_fft", 50);
 	add_topic("sensor_selection");
 	add_topic("sensors_status_imu", 200);

--- a/src/modules/sensors/vehicle_imu/CMakeLists.txt
+++ b/src/modules/sensors/vehicle_imu/CMakeLists.txt
@@ -43,4 +43,4 @@ target_compile_options(vehicle_imu
 		#-DDEBUG_BUILD
 )
 
-target_link_libraries(vehicle_imu PRIVATE px4_work_queue sensor_calibration)
+target_link_libraries(vehicle_imu PRIVATE mathlib px4_work_queue sensor_calibration)

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.cpp
@@ -51,6 +51,7 @@ VehicleIMU::VehicleIMU(int instance, uint8_t accel_index, uint8_t gyro_index, co
 	ModuleParams(nullptr),
 	ScheduledWorkItem(MODULE_NAME, config),
 	_sensor_accel_sub(ORB_ID(sensor_accel), accel_index),
+	_sensor_accel_fifo_sub(ORB_ID(sensor_accel_fifo), accel_index),
 	_sensor_gyro_sub(this, ORB_ID(sensor_gyro), gyro_index),
 	_instance(instance)
 {
@@ -77,6 +78,17 @@ VehicleIMU::VehicleIMU(int instance, uint8_t accel_index, uint8_t gyro_index, co
 VehicleIMU::~VehicleIMU()
 {
 	Stop();
+
+#if !defined(CONSTRAINED_FLASH)
+	delete[] _dynamic_notch_filter_esc_rpm;
+
+	perf_free(_dynamic_notch_filter_esc_rpm_disable_perf);
+	perf_free(_dynamic_notch_filter_esc_rpm_init_perf);
+	perf_free(_dynamic_notch_filter_esc_rpm_update_perf);
+
+	perf_free(_dynamic_notch_filter_fft_disable_perf);
+	perf_free(_dynamic_notch_filter_fft_update_perf);
+#endif // !CONSTRAINED_FLASH
 
 	perf_free(_accel_generation_gap_perf);
 	perf_free(_gyro_generation_gap_perf);
@@ -161,6 +173,69 @@ bool VehicleIMU::ParametersUpdate(bool force)
 			// force update
 			_update_integrator_config = true;
 		}
+
+#if !defined(CONSTRAINED_FLASH)
+
+		if (_param_imu_acc_dnf_en.get() & DynamicNotch::EscRpm) {
+
+			const int32_t esc_rpm_harmonics = math::constrain(_param_imu_acc_dnf_hmc.get(), (int32_t)1, (int32_t)7);
+
+			if (_dynamic_notch_filter_esc_rpm && (esc_rpm_harmonics != _esc_rpm_harmonics)) {
+				delete[] _dynamic_notch_filter_esc_rpm;
+				_dynamic_notch_filter_esc_rpm = nullptr;
+				_esc_rpm_harmonics = 0;
+			}
+
+			if (_dynamic_notch_filter_esc_rpm == nullptr) {
+
+				_dynamic_notch_filter_esc_rpm = new NotchFilterHarmonic[esc_rpm_harmonics];
+
+				if (_dynamic_notch_filter_esc_rpm) {
+					_esc_rpm_harmonics = esc_rpm_harmonics;
+
+					if (_dynamic_notch_filter_esc_rpm_disable_perf == nullptr) {
+						_dynamic_notch_filter_esc_rpm_disable_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": accel dynamic notch ESC RPM disable");
+					}
+
+					if (_dynamic_notch_filter_esc_rpm_init_perf == nullptr) {
+						_dynamic_notch_filter_esc_rpm_init_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": accel dynamic notch ESC RPM init");
+					}
+
+					if (_dynamic_notch_filter_esc_rpm_update_perf == nullptr) {
+						_dynamic_notch_filter_esc_rpm_update_perf = perf_alloc(PC_COUNT,
+								MODULE_NAME": accel dynamic notch ESC RPM update");
+					}
+
+				} else {
+					_esc_rpm_harmonics = 0;
+
+					perf_free(_dynamic_notch_filter_esc_rpm_disable_perf);
+					perf_free(_dynamic_notch_filter_esc_rpm_init_perf);
+					perf_free(_dynamic_notch_filter_esc_rpm_update_perf);
+
+					_dynamic_notch_filter_esc_rpm_disable_perf = nullptr;
+					_dynamic_notch_filter_esc_rpm_init_perf = nullptr;
+					_dynamic_notch_filter_esc_rpm_update_perf = nullptr;
+				}
+			}
+
+		} else {
+			DisableDynamicNotchEscRpm();
+		}
+
+		if (_param_imu_acc_dnf_en.get() & DynamicNotch::FFT) {
+			if (_dynamic_notch_filter_fft_disable_perf == nullptr) {
+				_dynamic_notch_filter_fft_disable_perf = perf_alloc(PC_COUNT, MODULE_NAME": accel dynamic notch FFT disable");
+				_dynamic_notch_filter_fft_update_perf = perf_alloc(PC_COUNT, MODULE_NAME": accel dynamic notch FFT update");
+			}
+
+		} else {
+			DisableDynamicNotchFFT();
+		}
+
+#endif // !CONSTRAINED_FLASH
 	}
 
 	return updated;
@@ -190,12 +265,59 @@ void VehicleIMU::Run()
 		}
 	}
 
+#if !defined(CONSTRAINED_FLASH)
+
+	// detect accel FIFO availability
+	if (!_accel_fifo_available && _sensor_accel_fifo_sub.advertised()) {
+		sensor_accel_fifo_s fifo_check;
+
+		if (_sensor_accel_fifo_sub.copy(&fifo_check)
+		    && (fifo_check.device_id == _accel_calibration.device_id())
+		    && (hrt_elapsed_time(&fifo_check.timestamp) < 1_s)) {
+			_accel_fifo_available = true;
+		}
+	}
+
+	// check if this is the primary accel for dynamic notch filtering
+	if (_sensor_selection_sub.updated() || !_sensor_selection_initialized) {
+		sensor_selection_s sensor_selection;
+
+		if (_sensor_selection_sub.copy(&sensor_selection)) {
+			const bool accel_device_ready = (_accel_calibration.device_id() != 0);
+
+			// Only latch sensor selection once the accel device_id is known
+			if (accel_device_ready) {
+				_sensor_selection_initialized = true;
+			}
+
+			const bool was_primary = _is_primary_accel;
+			_is_primary_accel = accel_device_ready
+					    && (sensor_selection.accel_device_id == _accel_calibration.device_id());
+
+			if (_is_primary_accel && !was_primary) {
+				UpdateDynamicNotchEscRpm(now_us, true);
+				UpdateDynamicNotchFFT(now_us, true);
+
+			} else if (!_is_primary_accel && was_primary) {
+				DisableDynamicNotchEscRpm();
+				DisableDynamicNotchFFT();
+			}
+		}
+	}
+
+	if (_is_primary_accel) {
+		UpdateDynamicNotchEscRpm(now_us);
+		UpdateDynamicNotchFFT(now_us);
+	}
+
+#endif // !CONSTRAINED_FLASH
+
 	// reset data gap monitor
 	_data_gap = false;
 
 	int sensor_sub_updates = 0;
 
-	while ((_sensor_gyro_sub.updated() || _sensor_accel_sub.updated())
+	while ((_sensor_gyro_sub.updated() || (!_accel_fifo_available && _sensor_accel_sub.updated()) || (_accel_fifo_available && _sensor_accel_fifo_sub.updated()))
 	       && (sensor_sub_updates < math::max(sensor_accel_s::ORB_QUEUE_LENGTH, sensor_gyro_s::ORB_QUEUE_LENGTH))) {
 		sensor_sub_updates++;
 
@@ -228,16 +350,34 @@ void VehicleIMU::Run()
 		// update accel until integrator ready and caught up to gyro
 		int sensor_accel_sub_updates = 0;
 
-		while (_sensor_accel_sub.updated()
-		       && (sensor_accel_sub_updates < sensor_accel_s::ORB_QUEUE_LENGTH)
-		       && (!_accel_integrator.integral_ready() || !_intervals_configured || _data_gap
-			   || (_accel_timestamp_sample_last < (_gyro_timestamp_sample_last - 0.5f * _accel_interval_us)))
-		      ) {
+#if !defined(CONSTRAINED_FLASH)
 
-			sensor_accel_sub_updates++;
+		if (_accel_fifo_available) {
+			while (_sensor_accel_fifo_sub.updated()
+			       && (sensor_accel_sub_updates < sensor_accel_fifo_s::ORB_QUEUE_LENGTH)
+			       && (!_accel_integrator.integral_ready() || !_intervals_configured || _data_gap
+				   || (_accel_timestamp_sample_last < (_gyro_timestamp_sample_last - 0.5f * _accel_interval_us)))
+			      ) {
+				sensor_accel_sub_updates++;
 
-			if (UpdateAccel()) {
-				updated = true;
+				if (UpdateAccelFifo()) {
+					updated = true;
+				}
+			}
+
+		} else
+#endif // !CONSTRAINED_FLASH
+		{
+			while (_sensor_accel_sub.updated()
+			       && (sensor_accel_sub_updates < sensor_accel_s::ORB_QUEUE_LENGTH)
+			       && (!_accel_integrator.integral_ready() || !_intervals_configured || _data_gap
+				   || (_accel_timestamp_sample_last < (_gyro_timestamp_sample_last - 0.5f * _accel_interval_us)))
+			      ) {
+				sensor_accel_sub_updates++;
+
+				if (UpdateAccel()) {
+					updated = true;
+				}
 			}
 		}
 
@@ -353,7 +493,19 @@ bool VehicleIMU::UpdateAccel()
 
 		const Vector3f accel_raw{accel.x, accel.y, accel.z};
 		_raw_accel_mean.update(accel_raw);
-		_accel_integrator.put(accel_raw, dt);
+
+		float accel_data[3] {accel_raw(0), accel_raw(1), accel_raw(2)};
+
+#if !defined(CONSTRAINED_FLASH)
+
+		for (int axis = 0; axis < 3; axis++) {
+			FilterAcceleration(axis, &accel_data[axis], 1);
+		}
+
+#endif // !CONSTRAINED_FLASH
+
+		const Vector3f accel_filtered{accel_data[0], accel_data[1], accel_data[2]};
+		_accel_integrator.put(accel_filtered, dt);
 
 		updated = true;
 
@@ -406,6 +558,193 @@ bool VehicleIMU::UpdateAccel()
 
 	return updated;
 }
+
+#if !defined(CONSTRAINED_FLASH)
+
+bool VehicleIMU::UpdateAccelFifo()
+{
+	bool updated = false;
+
+	sensor_accel_fifo_s accel_fifo;
+
+	if (_sensor_accel_fifo_sub.update(&accel_fifo)) {
+		if (_sensor_accel_fifo_sub.get_last_generation() != _accel_last_generation + 1) {
+			_data_gap = true;
+			perf_count(_accel_generation_gap_perf);
+
+		} else {
+			// collect sample interval average for filters
+			if (accel_fifo.timestamp_sample > _accel_timestamp_sample_last) {
+				if (_accel_timestamp_sample_last != 0) {
+					const float interval_us = accel_fifo.timestamp_sample - _accel_timestamp_sample_last;
+
+					_accel_mean_interval_us.update(interval_us);
+					_accel_fifo_mean_interval_us.update(accel_fifo.dt);
+
+					// check measured interval periodically
+					if (_accel_mean_interval_us.valid() && (_accel_mean_interval_us.count() % 10 == 0)) {
+						const float interval_mean = _accel_mean_interval_us.mean();
+
+						const bool diff_exceeds_stddev = sq(interval_mean - _accel_interval_us) > _accel_mean_interval_us.variance();
+
+						if (!PX4_ISFINITE(_accel_interval_us) || diff_exceeds_stddev) {
+							_update_integrator_config = true;
+						}
+					}
+				}
+
+			} else {
+				PX4_ERR("%d - accel FIFO %" PRIu32 " timestamp error timestamp_sample: %" PRIu64 ", previous: %" PRIu64,
+					_instance, accel_fifo.device_id, accel_fifo.timestamp_sample, _accel_timestamp_sample_last);
+			}
+		}
+
+		_accel_last_generation = _sensor_accel_fifo_sub.get_last_generation();
+
+		_accel_calibration.set_device_id(accel_fifo.device_id);
+
+		const int N = math::min((int)accel_fifo.samples, (int)(sizeof(accel_fifo.x) / sizeof(accel_fifo.x[0])));
+		const float dt = accel_fifo.dt * 1e-6f;
+
+		if ((N > 0) && (dt > 0.f)) {
+			// scale raw int16 FIFO data to float
+			static constexpr int FIFO_SIZE_MAX = sizeof(accel_fifo.x) / sizeof(accel_fifo.x[0]);
+			float data[3][FIFO_SIZE_MAX];
+
+			for (int axis = 0; axis < 3; axis++) {
+				int16_t *raw[] {accel_fifo.x, accel_fifo.y, accel_fifo.z};
+
+				for (int n = 0; n < N; n++) {
+					data[axis][n] = accel_fifo.scale * raw[axis][n];
+				}
+			}
+
+			// update raw accel statistics before filtering (consistent with UpdateAccel)
+			for (int n = 0; n < N; n++) {
+				const matrix::Vector3f accel_raw{data[0][n], data[1][n], data[2][n]};
+				_raw_accel_mean.update(accel_raw);
+			}
+
+			// apply dynamic notch filters
+			for (int axis = 0; axis < 3; axis++) {
+				FilterAcceleration(axis, data[axis], N);
+			}
+
+			// integrate each filtered sample
+			for (int n = 0; n < N; n++) {
+				const matrix::Vector3f accel_filtered{data[0][n], data[1][n], data[2][n]};
+				_accel_integrator.put(accel_filtered, dt);
+			}
+
+			_accel_timestamp_sample_last = accel_fifo.timestamp_sample;
+			updated = true;
+		}
+
+		// drain sensor_accel for metadata not available in FIFO message
+		// (temperature, clipping, error count)
+		sensor_accel_s accel;
+
+		while (_sensor_accel_sub.update(&accel)) {
+			// error count
+			if (accel.error_count != _status.accel_error_count) {
+				_publish_status = true;
+				_status.accel_error_count = accel.error_count;
+			}
+
+			// temperature average
+			if (PX4_ISFINITE(accel.temperature)) {
+				if ((_accel_temperature_sum_count == 0) || !PX4_ISFINITE(_accel_temperature_sum)) {
+					_accel_temperature_sum = accel.temperature;
+					_accel_temperature_sum_count = 1;
+
+				} else {
+					_accel_temperature_sum += accel.temperature;
+					_accel_temperature_sum_count += 1;
+				}
+			}
+
+			// clipping
+			if (accel.clip_counter[0] > 0 || accel.clip_counter[1] > 0 || accel.clip_counter[2] > 0) {
+				const Vector3f clipping{_accel_calibration.rotation() *
+							Vector3f{(float)accel.clip_counter[0], (float)accel.clip_counter[1], (float)accel.clip_counter[2]}};
+
+				const uint8_t clip_x = roundf(fabsf(clipping(0)));
+				const uint8_t clip_y = roundf(fabsf(clipping(1)));
+				const uint8_t clip_z = roundf(fabsf(clipping(2)));
+
+				_status.accel_clipping[0] += clip_x;
+				_status.accel_clipping[1] += clip_y;
+				_status.accel_clipping[2] += clip_z;
+
+				if (clip_x > 0) {
+					_delta_velocity_clipping |= vehicle_imu_s::CLIPPING_X;
+				}
+
+				if (clip_y > 0) {
+					_delta_velocity_clipping |= vehicle_imu_s::CLIPPING_Y;
+				}
+
+				if (clip_z > 0) {
+					_delta_velocity_clipping |= vehicle_imu_s::CLIPPING_Z;
+				}
+
+				_publish_status = true;
+
+				if (_notify_clipping && _accel_calibration.enabled()
+				    && (hrt_elapsed_time(&_last_accel_clipping_notify_time) > 3_s)) {
+					const uint64_t clipping_total = _status.accel_clipping[0] + _status.accel_clipping[1]
+									+ _status.accel_clipping[2];
+
+					if (clipping_total > _last_accel_clipping_notify_total_count + 1000) {
+						mavlink_log_critical(&_mavlink_log_pub, "Accel %" PRIu8 " clipping, not safe to fly!\t",
+								     _instance);
+						/* EVENT
+						 * @description Land now, and check the vehicle setup.
+						 * Clipping can lead to fly-aways.
+						 */
+						events::send<uint8_t>(events::ID("vehicle_imu_accel_clipping"), events::Log::Critical,
+								      "Accel {1} clipping, not safe to fly!", _instance);
+						_last_accel_clipping_notify_time = accel.timestamp_sample;
+						_last_accel_clipping_notify_total_count = clipping_total;
+					}
+				}
+			}
+		}
+	}
+
+	return updated;
+}
+
+void VehicleIMU::FilterAcceleration(int axis, float data[], int N)
+{
+	if (_is_primary_accel) {
+		// Apply dynamic notch filter from ESC RPM
+		if (_dynamic_notch_filter_esc_rpm) {
+			for (int esc = 0; esc < MAX_NUM_ESCS; esc++) {
+				if (_esc_available[esc]) {
+					for (int harmonic = 0; harmonic < _esc_rpm_harmonics; harmonic++) {
+						auto &nf = _dynamic_notch_filter_esc_rpm[harmonic][axis][esc];
+
+						if (nf.getNotchFreq() > 0.f) {
+							nf.applyArray(data, N);
+						}
+					}
+				}
+			}
+		}
+
+		// Apply dynamic notch filter from FFT
+		if (_dynamic_notch_fft_available) {
+			for (int peak = MAX_NUM_FFT_PEAKS - 1; peak >= 0; peak--) {
+				if (_dynamic_notch_filter_fft[axis][peak].getNotchFreq() > 0.f) {
+					_dynamic_notch_filter_fft[axis][peak].applyArray(data, N);
+				}
+			}
+		}
+	}
+}
+
+#endif // !CONSTRAINED_FLASH
 
 bool VehicleIMU::UpdateGyro()
 {
@@ -785,6 +1124,226 @@ void VehicleIMU::PrintStatus()
 	_accel_calibration.PrintStatus();
 	_gyro_calibration.PrintStatus();
 }
+
+#if !defined(CONSTRAINED_FLASH)
+
+void VehicleIMU::UpdateDynamicNotchEscRpm(const hrt_abstime &time_now_us, bool force)
+{
+	const bool enabled = _dynamic_notch_filter_esc_rpm && (_param_imu_acc_dnf_en.get() & DynamicNotch::EscRpm);
+
+	if (!enabled) {
+		return;
+	}
+
+	if (_esc_status_sub.updated() || force) {
+
+		bool axis_init[3] {false, false, false};
+
+		esc_status_s esc_status;
+
+		if (_esc_status_sub.copy(&esc_status) && (time_now_us < esc_status.timestamp + DYNAMIC_NOTCH_FILTER_TIMEOUT)) {
+
+			const float bandwidth_hz = _param_imu_acc_dnf_bw.get();
+			const float freq_min = math::max(_param_imu_acc_dnf_min.get(), bandwidth_hz);
+
+			// use FIFO raw sample rate when available, otherwise publication rate
+			float sample_rate_hz = 0.f;
+
+			if (_accel_fifo_available && _accel_fifo_mean_interval_us.valid()) {
+				sample_rate_hz = 1e6f / _accel_fifo_mean_interval_us.mean();
+
+			} else if (_accel_mean_interval_us.valid()) {
+				sample_rate_hz = 1e6f / _accel_mean_interval_us.mean();
+			}
+
+			if (sample_rate_hz <= 0.f) {
+				return;
+			}
+
+			for (size_t esc = 0; esc < math::min(esc_status.esc_count, (uint8_t)MAX_NUM_ESCS); esc++) {
+				const esc_report_s &esc_report = esc_status.esc[esc];
+
+				const bool esc_connected = (esc_status.esc_online_flags & (1 << esc)) || (esc_report.esc_rpm != 0);
+
+				if (esc_connected && (time_now_us < esc_report.timestamp + DYNAMIC_NOTCH_FILTER_TIMEOUT)) {
+
+					const float esc_hz = abs(esc_report.esc_rpm) / 60.f;
+
+					const bool force_update = force || !_esc_available[esc];
+
+					for (int harmonic = 0; harmonic < _esc_rpm_harmonics; harmonic++) {
+						const float frequency_hz = math::max(esc_hz * (harmonic + 1), freq_min + (harmonic * 0.5f * bandwidth_hz));
+
+						for (int axis = 0; axis < 3; axis++) {
+							auto &nf = _dynamic_notch_filter_esc_rpm[harmonic][axis][esc];
+
+							const float notch_freq_delta = fabsf(nf.getNotchFreq() - frequency_hz);
+
+							const bool notch_freq_changed = (notch_freq_delta > 0.1f);
+
+							const bool allow_update = !axis_init[axis] || (nf.initialized() && notch_freq_delta < nf.getBandwidth());
+
+							if ((force_update || notch_freq_changed) && allow_update) {
+								if (nf.setParameters(sample_rate_hz, frequency_hz, bandwidth_hz)) {
+									perf_count(_dynamic_notch_filter_esc_rpm_update_perf);
+
+									if (!nf.initialized()) {
+										perf_count(_dynamic_notch_filter_esc_rpm_init_perf);
+										axis_init[axis] = true;
+									}
+								}
+							}
+						}
+					}
+
+					_esc_available.set(esc, true);
+					_last_esc_rpm_notch_update[esc] = esc_report.timestamp;
+				}
+			}
+		}
+	}
+
+	// check notch filter timeout unconditionally so stale filters are disabled
+	// even when ESC messages stop publishing
+	for (size_t esc = 0; esc < MAX_NUM_ESCS; esc++) {
+		if (_esc_available[esc] && (time_now_us > _last_esc_rpm_notch_update[esc] + DYNAMIC_NOTCH_FILTER_TIMEOUT)) {
+
+			for (int harmonic = _esc_rpm_harmonics - 1; harmonic >= 0; harmonic--) {
+				for (int axis = 0; axis < 3; axis++) {
+					auto &nf = _dynamic_notch_filter_esc_rpm[harmonic][axis][esc];
+
+					if (nf.getNotchFreq() > 0.f) {
+						nf.disable();
+						perf_count(_dynamic_notch_filter_esc_rpm_disable_perf);
+					}
+				}
+			}
+
+			_esc_available.set(esc, false);
+		}
+	}
+}
+
+void VehicleIMU::DisableDynamicNotchEscRpm()
+{
+	if (_dynamic_notch_filter_esc_rpm) {
+		for (int harmonic = 0; harmonic < _esc_rpm_harmonics; harmonic++) {
+			for (int axis = 0; axis < 3; axis++) {
+				for (int esc = 0; esc < MAX_NUM_ESCS; esc++) {
+					_dynamic_notch_filter_esc_rpm[harmonic][axis][esc].disable();
+					_esc_available.set(esc, false);
+					perf_count(_dynamic_notch_filter_esc_rpm_disable_perf);
+				}
+			}
+		}
+	}
+}
+
+void VehicleIMU::UpdateDynamicNotchFFT(const hrt_abstime &time_now_us, bool force)
+{
+	const bool enabled = _param_imu_acc_dnf_en.get() & DynamicNotch::FFT;
+
+	if (!enabled) {
+		return;
+	}
+
+	if (_sensor_accel_fft_sub.updated() || force) {
+
+		if (!_dynamic_notch_fft_available) {
+			// force update filters if previously disabled
+			force = true;
+		}
+
+		sensor_accel_fft_s sensor_accel_fft;
+
+		if (_sensor_accel_fft_sub.copy(&sensor_accel_fft)
+		    && (sensor_accel_fft.device_id == _accel_calibration.device_id())
+		    && (time_now_us < sensor_accel_fft.timestamp + DYNAMIC_NOTCH_FILTER_TIMEOUT)) {
+
+			const float peak_freq_min = _param_imu_acc_dnf_min.get();
+
+			const float bandwidth = math::constrain(sensor_accel_fft.resolution_hz, 8.f, 30.f);
+
+			// use FIFO raw sample rate when available, otherwise publication rate
+			float sample_rate_hz = 0.f;
+
+			if (_accel_fifo_available && _accel_fifo_mean_interval_us.valid()) {
+				sample_rate_hz = 1e6f / _accel_fifo_mean_interval_us.mean();
+
+			} else if (_accel_mean_interval_us.valid()) {
+				sample_rate_hz = 1e6f / _accel_mean_interval_us.mean();
+			}
+
+			if (sample_rate_hz <= 0.f) {
+				return;
+			}
+
+			// reject if FFT was computed at a different sample rate than the notch filters use
+			if (sensor_accel_fft.sensor_sample_rate_hz > 0.f
+			    && (fabsf(sensor_accel_fft.sensor_sample_rate_hz - sample_rate_hz) / sample_rate_hz) > 0.02f) {
+				return;
+			}
+
+			float *peak_frequencies[] {sensor_accel_fft.peak_frequencies_x, sensor_accel_fft.peak_frequencies_y, sensor_accel_fft.peak_frequencies_z};
+
+			bool any_peak_active = false;
+
+			for (int axis = 0; axis < 3; axis++) {
+				for (int peak = 0; peak < MAX_NUM_FFT_PEAKS; peak++) {
+
+					const float peak_freq = peak_frequencies[axis][peak];
+
+					auto &nf = _dynamic_notch_filter_fft[axis][peak];
+
+					if (peak_freq > peak_freq_min) {
+						// update filter parameters if frequency changed or forced
+						if (force || !nf.initialized() || (fabsf(nf.getNotchFreq() - peak_freq) > 0.1f)) {
+							nf.setParameters(sample_rate_hz, peak_freq, bandwidth);
+							perf_count(_dynamic_notch_filter_fft_update_perf);
+						}
+
+						any_peak_active = true;
+
+					} else {
+						// disable this notch filter (if it isn't already)
+						if (nf.getNotchFreq() > 0.f) {
+							nf.disable();
+							perf_count(_dynamic_notch_filter_fft_disable_perf);
+						}
+					}
+				}
+			}
+
+			_dynamic_notch_fft_available = any_peak_active;
+			_last_fft_notch_update = sensor_accel_fft.timestamp;
+
+		} else {
+			DisableDynamicNotchFFT();
+		}
+	}
+
+	// check FFT timeout unconditionally so stale filters are disabled
+	// even when FFT messages stop publishing
+	if (_dynamic_notch_fft_available && (time_now_us > _last_fft_notch_update + DYNAMIC_NOTCH_FILTER_TIMEOUT)) {
+		DisableDynamicNotchFFT();
+	}
+}
+
+void VehicleIMU::DisableDynamicNotchFFT()
+{
+	if (_dynamic_notch_fft_available) {
+		for (int axis = 0; axis < 3; axis++) {
+			for (int peak = 0; peak < MAX_NUM_FFT_PEAKS; peak++) {
+				_dynamic_notch_filter_fft[axis][peak].disable();
+				perf_count(_dynamic_notch_filter_fft_disable_perf);
+			}
+		}
+
+		_dynamic_notch_fft_available = false;
+	}
+}
+
+#endif // !CONSTRAINED_FLASH
 
 void VehicleIMU::SensorCalibrationUpdate()
 {

--- a/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
+++ b/src/modules/sensors/vehicle_imu/VehicleIMU.hpp
@@ -35,9 +35,11 @@
 
 #include <Integrator.hpp>
 
+#include <containers/Bitset.hpp>
 #include <lib/mathlib/math/Limits.hpp>
 #include <lib/mathlib/math/WelfordMean.hpp>
 #include <lib/mathlib/math/WelfordMeanVector.hpp>
+#include <lib/mathlib/math/filter/NotchFilter.hpp>
 #include <lib/matrix/matrix/math.hpp>
 #include <lib/perf/perf_counter.h>
 #include <lib/sensor_calibration/Accelerometer.hpp>
@@ -50,10 +52,14 @@
 #include <uORB/Subscription.hpp>
 #include <uORB/SubscriptionMultiArray.hpp>
 #include <uORB/SubscriptionCallback.hpp>
+#include <uORB/topics/esc_status.h>
 #include <uORB/topics/estimator_sensor_bias.h>
 #include <uORB/topics/parameter_update.h>
 #include <uORB/topics/sensor_accel.h>
 #include <uORB/topics/sensor_gyro.h>
+#include <uORB/topics/sensor_accel_fft.h>
+#include <uORB/topics/sensor_accel_fifo.h>
+#include <uORB/topics/sensor_selection.h>
 #include <uORB/topics/vehicle_control_mode.h>
 #include <uORB/topics/vehicle_imu.h>
 #include <uORB/topics/vehicle_imu_status.h>
@@ -86,6 +92,17 @@ private:
 
 	void UpdateIntegratorConfiguration();
 
+#if !defined(CONSTRAINED_FLASH)
+	bool UpdateAccelFifo();
+	void FilterAcceleration(int axis, float data[], int N);
+
+	void UpdateDynamicNotchEscRpm(const hrt_abstime &time_now_us, bool force = false);
+	void DisableDynamicNotchEscRpm();
+
+	void UpdateDynamicNotchFFT(const hrt_abstime &time_now_us, bool force = false);
+	void DisableDynamicNotchFFT();
+#endif // !CONSTRAINED_FLASH
+
 	inline void UpdateAccelVibrationMetrics(const matrix::Vector3f &acceleration);
 	inline void UpdateGyroVibrationMetrics(const matrix::Vector3f &angular_velocity);
 
@@ -107,7 +124,14 @@ private:
 	uORB::SubscriptionMultiArray<estimator_sensor_bias_s> _estimator_sensor_bias_subs{ORB_ID::estimator_sensor_bias};
 
 	uORB::Subscription _sensor_accel_sub;
+	uORB::Subscription _sensor_accel_fifo_sub;
 	uORB::SubscriptionCallbackWorkItem _sensor_gyro_sub;
+
+#if !defined(CONSTRAINED_FLASH)
+	uORB::Subscription _esc_status_sub{ORB_ID(esc_status)};
+	uORB::Subscription _sensor_accel_fft_sub{ORB_ID(sensor_accel_fft)};
+	uORB::Subscription _sensor_selection_sub{ORB_ID(sensor_selection)};
+#endif // !CONSTRAINED_FLASH
 
 	uORB::Subscription _vehicle_control_mode_sub{ORB_ID(vehicle_control_mode)};
 
@@ -195,6 +219,47 @@ private:
 
 	hrt_abstime _in_flight_calibration_check_timestamp_last{0};
 
+#if !defined(CONSTRAINED_FLASH)
+
+	enum DynamicNotch {
+		EscRpm = 1,
+		FFT    = 2,
+	};
+
+	static constexpr hrt_abstime DYNAMIC_NOTCH_FILTER_TIMEOUT = 3_s;
+
+	// ESC RPM
+	static constexpr int MAX_NUM_ESCS = sizeof(esc_status_s::esc) / sizeof(esc_status_s::esc[0]);
+
+	using NotchFilterHarmonic = math::NotchFilter<float>[3][MAX_NUM_ESCS];
+	NotchFilterHarmonic *_dynamic_notch_filter_esc_rpm{nullptr};
+
+	int _esc_rpm_harmonics{0};
+	px4::Bitset<MAX_NUM_ESCS> _esc_available{};
+	hrt_abstime _last_esc_rpm_notch_update[MAX_NUM_ESCS] {};
+
+	perf_counter_t _dynamic_notch_filter_esc_rpm_disable_perf{nullptr};
+	perf_counter_t _dynamic_notch_filter_esc_rpm_init_perf{nullptr};
+	perf_counter_t _dynamic_notch_filter_esc_rpm_update_perf{nullptr};
+
+	// FFT
+	static constexpr int MAX_NUM_FFT_PEAKS = sizeof(sensor_accel_fft_s::peak_frequencies_x)
+			/ sizeof(sensor_accel_fft_s::peak_frequencies_x[0]);
+
+	math::NotchFilter<float> _dynamic_notch_filter_fft[3][MAX_NUM_FFT_PEAKS] {};
+
+	perf_counter_t _dynamic_notch_filter_fft_disable_perf{nullptr};
+	perf_counter_t _dynamic_notch_filter_fft_update_perf{nullptr};
+
+	hrt_abstime _last_fft_notch_update{0};
+	bool _dynamic_notch_fft_available{false};
+
+	bool _is_primary_accel{false};
+	bool _sensor_selection_initialized{false};
+#endif // !CONSTRAINED_FLASH
+
+	bool _accel_fifo_available{false};
+
 	perf_counter_t _accel_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": accel data gap")};
 	perf_counter_t _gyro_generation_gap_perf{perf_alloc(PC_COUNT, MODULE_NAME": gyro data gap")};
 
@@ -202,6 +267,12 @@ private:
 		(ParamInt<px4::params::IMU_INTEG_RATE>) _param_imu_integ_rate,
 		(ParamBool<px4::params::SENS_IMU_AUTOCAL>) _param_sens_imu_autocal,
 		(ParamBool<px4::params::SENS_IMU_CLPNOTI>) _param_sens_imu_notify_clipping
+#if !defined(CONSTRAINED_FLASH)
+		, (ParamInt<px4::params::IMU_ACC_DNF_EN>) _param_imu_acc_dnf_en,
+		(ParamInt<px4::params::IMU_ACC_DNF_HMC>) _param_imu_acc_dnf_hmc,
+		(ParamFloat<px4::params::IMU_ACC_DNF_BW>) _param_imu_acc_dnf_bw,
+		(ParamFloat<px4::params::IMU_ACC_DNF_MIN>) _param_imu_acc_dnf_min
+#endif // !CONSTRAINED_FLASH
 	)
 };
 

--- a/src/modules/sensors/vehicle_imu/imu_parameters.yaml
+++ b/src/modules/sensors/vehicle_imu/imu_parameters.yaml
@@ -34,3 +34,49 @@ parameters:
       category: System
       type: boolean
       default: 1
+    IMU_ACC_DNF_EN:
+      description:
+        short: IMU accel dynamic notch filtering
+        long: |-
+          Enable bank of dynamically updating notch filters.
+          Requires ESC RPM feedback or onboard accel FFT (IMU_ACC_FFT_EN).
+          Only applied to the primary accelerometer used by the estimator.
+      type: bitmask
+      bit:
+        0: ESC RPM
+        1: FFT
+      default: 0
+      min: 0
+      max: 3
+    IMU_ACC_DNF_BW:
+      description:
+        short: IMU accel ESC notch filter bandwidth
+        long: Bandwidth per notch filter when using dynamic notch filtering with ESC
+          RPM.
+      type: float
+      default: 15.0
+      unit: Hz
+      increment: 0.1
+      decimal: 1
+      min: 5
+      max: 30
+    IMU_ACC_DNF_HMC:
+      description:
+        short: IMU accel dynamic notch filter harmonics
+        long: ESC RPM number of harmonics (multiples of RPM) for ESC RPM dynamic notch
+          filtering.
+      type: int32
+      default: 3
+      min: 1
+      max: 7
+    IMU_ACC_DNF_MIN:
+      description:
+        short: IMU accel dynamic notch filter minimum frequency
+        long: Minimum notch filter frequency in Hz.
+      type: float
+      default: 25.0
+      unit: Hz
+      increment: 0.1
+      decimal: 1
+      min: 5
+      max: 500


### PR DESCRIPTION
## Summary
- Add new `accel_fft` module that performs FFT analysis on accelerometer FIFO data, publishing per-axis peak frequencies and SNR via `sensor_accel_fft`
- Add dynamic notch filters to `VehicleIMU` applied to the primary accelerometer before integration into delta velocities for the EKF
- **ESC RPM**: per-ESC, per-harmonic, per-axis notch filters driven by ESC RPM feedback
- **FFT**: per-axis, per-peak notch filters driven by `sensor_accel_fft` to catch non-RPM vibration modes (structural resonances, bearing noise, etc.)
- Add FIFO-based accel path in `VehicleIMU` (`UpdateAccelFifo`) for higher sample rate filtering, with `sensor_accel` drained for metadata (temperature, clipping, error count)
- Autostart `accel_fft` via `IMU_ACC_FFT_EN` in rcS (NuttX and POSIX)
- Guarded with `CONSTRAINED_FLASH` for resource-limited targets

### Parameters
- `IMU_ACC_FFT_EN` — enable accel FFT module (reboot required)
- `IMU_ACC_FFT_LEN` — FFT length (256/512/1024)
- `IMU_ACC_FFT_MIN` / `IMU_ACC_FFT_MAX` — FFT frequency range
- `IMU_ACC_FFT_SNR` — minimum SNR for peak detection
- `IMU_ACC_DNF_EN` — dynamic notch filter enable bitmask (bit 0 = ESC RPM, bit 1 = FFT)
- `IMU_ACC_DNF_BW` — ESC notch bandwidth
- `IMU_ACC_DNF_HMC` — ESC RPM harmonics (1-7)
- `IMU_ACC_DNF_MIN` — minimum notch filter frequency

## Test plan
- [ ] SITL: enable `IMU_ACC_DNF_EN` = 1 (ESC RPM), verify no adverse behavior
- [ ] SITL: enable `IMU_ACC_DNF_EN` = 3 (ESC RPM + FFT) with `IMU_ACC_FFT_EN`, verify filters activate
- [ ] Hardware: compare Z-velocity estimation noise with/without accel DNF on a vibration-prone frame
- [ ] Verify filter disable on ESC/FFT timeout (3s) and sensor selection change
- [ ] Verify `CONSTRAINED_FLASH` targets build without DNF code