### PR TITLE
feat(ekf2): add thrust-based baro propwash compensation

### DIFF
--- a/Tools/baro_compensation/README.md
+++ b/Tools/baro_compensation/README.md
@@ -1,0 +1,172 @@
+# Barometer Thrust Compensation Calibration
+
+Tool for calibrating the EKF2 barometer thrust compensation parameters
+(`EKF2_PCOEF_THR` and `EKF2_PCOEF_TTAU`) from flight log data.
+
+## Background
+
+On multirotor vehicles, propwash from the rotors changes the static pressure at
+the barometer sensor. This creates a thrust-dependent altitude error: as thrust
+increases, the baro reading shifts (typically reading higher altitude due to
+pressure depression, though the direction depends on sensor placement).
+
+The EKF2 can compensate for this by applying a correction to the barometer
+measurement:
+
+```
+corrected_baro_alt = raw_baro_alt + EKF2_PCOEF_THR * filtered_thrust
+```
+
+where `filtered_thrust` is the normalized thrust magnitude [0, 1] passed through
+a first-order low-pass filter with time constant `EKF2_PCOEF_TTAU`. The filter
+models the delay between a thrust setpoint change and the resulting pressure
+change at the sensor (motor spin-up, propwash development, sensor response).
+
+This tool identifies the optimal values for both parameters by comparing
+barometer altitude against a range sensor (ground truth) during hover flight.
+
+## Prerequisites
+
+- **Range sensor**: A downward-facing lidar or sonar is required as the altitude
+  ground truth. The range sensor must be logging `distance_sensor`.
+- **Python packages**: `pyulog`, `numpy`, `scipy`, `matplotlib`
+
+  ```bash
+  pip install pyulog numpy scipy matplotlib
+  ```
+
+## Data Collection
+
+### Logging
+
+The default PX4 logging profile includes all required topics:
+- `vehicle_air_data` (barometer altitude)
+- `distance_sensor` (range sensor)
+- `vehicle_thrust_setpoint` (thrust)
+
+For higher-rate baro data (better calibration resolution), enable the
+**high rate** logging profile before flight:
+
+```
+param set SDLOG_PROFILE 3
+```
+
+This adds high-rate `vehicle_air_data` and `estimator_aid_src_baro_hgt` logging.
+
+### Flight Procedure
+
+1. **Disable existing compensation** before the calibration flight:
+   ```
+   param set EKF2_PCOEF_THR 0.0
+   param set EKF2_PCOEF_TTAU 0.0
+   ```
+
+2. **Fly a hover** at 2-5 m AGL (above ground effect height) for at least 60
+   seconds. Include some gentle altitude changes and throttle variation — the
+   calibration needs thrust variation to identify the relationship. Avoid
+   aggressive maneuvers.
+
+3. **Land and download** the `.ulg` log file.
+
+## Usage
+
+```bash
+cd PX4-Autopilot/Tools/baro_compensation
+
+python3 baro_thrust_calibration.py <path/to/log.ulg>
+
+# Save output to a specific directory:
+python3 baro_thrust_calibration.py <path/to/log.ulg> --output-dir /tmp/results
+```
+
+## Output
+
+### Console
+
+The tool prints a summary including:
+- Baro error statistics (mean offset and standard deviation vs range sensor)
+- Thrust-baro correlation strength
+- Identified model parameters (gain K, time constant tau, R²)
+- **Recommended `EKF2_PCOEF_THR` and `EKF2_PCOEF_TTAU` values**
+
+### PDF Report (`baro_calibration.pdf`)
+
+**Page 1 — Data Overview**:
+- Baro altitude vs range sensor altitude over time
+- Baro error timeseries (baro minus range sensor)
+- Thrust magnitude timeseries
+
+The gap between baro and range sensor lines shows the pressurization error. If
+the error tracks thrust changes, compensation will help.
+
+**Page 2 — Calibration Results**:
+- **Cross-correlation**: Shows the delay structure between thrust and baro error.
+  A peak at positive lag means the baro error lags behind thrust changes.
+- **R² vs tau**: Shows model fit quality across filter time constants. The best
+  tau is marked — this becomes `EKF2_PCOEF_TTAU`.
+- **Before/after**: Raw baro error vs compensated error during hover. The
+  compensated trace should be closer to zero.
+- **Recommended parameters**: The identified values to set.
+
+**Page 3 — Scatter Plots**:
+- Raw baro error vs thrust: shows the linear relationship (slope ≈ K)
+- Compensated error vs thrust: should show reduced correlation after compensation
+
+## How the Algorithm Works
+
+1. **Baro error computation**: The baro altitude (zeroed at arm time) is
+   compared against the range sensor to get `baro_error = baro_alt - range_dist`
+   at each range sensor sample.
+
+2. **Hover extraction**: The middle 60% of the armed period is used as the
+   analysis window, avoiding takeoff/landing transients.
+
+3. **Detrending**: A linear trend is removed from the baro error to isolate
+   thrust-induced variation from slow thermal drift.
+
+4. **Cross-correlation**: Computed between detrended baro error and detrended
+   thrust to visualize the delay structure.
+
+5. **Grid search**: For each candidate time constant tau:
+   - Apply a first-order LPF to the thrust signal: `alpha = dt / (dt + tau)`
+   - Fit `baro_error = K * filtered_thrust + c` via least-squares
+   - Compute R² (fraction of error variance explained by thrust)
+
+6. **Best model**: The tau with highest R² is selected. The gain K and tau
+   become the recommended parameters:
+   - `EKF2_PCOEF_THR = -K` (negated because the EKF adds the correction)
+   - `EKF2_PCOEF_TTAU = tau`
+
+## Applying Parameters
+
+After calibration, set the parameters on the vehicle:
+
+```
+param set EKF2_PCOEF_THR <value>
+param set EKF2_PCOEF_TTAU <value>
+```
+
+Then fly again and re-run the tool on the new log to verify the compensation is
+working. The baro error should show reduced correlation with thrust.
+
+## Interpreting Results
+
+| Metric | Good | Marginal | Poor |
+|--------|------|----------|------|
+| Thrust correlation \|r\| | > 0.6 | 0.3 - 0.6 | < 0.3 |
+| Model R² | > 0.3 | 0.1 - 0.3 | < 0.1 |
+| Compensated \|r\| | < 0.2 | 0.2 - 0.4 | > 0.4 |
+
+- **Low R²**: Thrust is not the dominant baro error source. Consider thermal
+  drift, ground effect, or sensor placement issues.
+- **R² improvement from lag ≈ 0**: The system delay is short enough that
+  `EKF2_PCOEF_TTAU = 0` is fine (no filtering needed).
+- **Very large K (> 5 m)**: May indicate a sensor mounting issue. The baro
+  should be shielded from direct propwash where possible.
+
+## Parameters Reference
+
+| Parameter | Description | Range | Default |
+|-----------|-------------|-------|---------|
+| `EKF2_PCOEF_THR` | Baro altitude correction per unit thrust [m] | -10 to 10 | 0.0 |
+| `EKF2_PCOEF_TTAU` | Thrust filter time constant [s] | 0 to 2 | 0.0 |

--- a/Tools/baro_compensation/baro_thrust_calibration.py
+++ b/Tools/baro_compensation/baro_thrust_calibration.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""
+Barometer thrust compensation calibration tool.
+
+Identifies optimal EKF2_PCOEF_THR and EKF2_PCOEF_TTAU parameters by comparing
+barometer altitude against a range sensor (ground truth) during hover flight.
+
+The tool fits a first-order lag model to the thrust-induced baro error:
+
+    baro_error = K * LPF(thrust, tau) + c
+
+where K is the static gain (meters per unit thrust) and tau is the filter time
+constant (seconds). The EKF applies: baro_alt += EKF2_PCOEF_THR * filtered_thrust
+to cancel this error, so EKF2_PCOEF_THR = -K.
+
+Requirements:
+    - Flight log (.ulg) from a hover flight with a range sensor (lidar/sonar)
+    - Python packages: pyulog, numpy, scipy, matplotlib
+
+Usage:
+    python3 baro_thrust_calibration.py <log.ulg> [--output-dir <dir>]
+
+Outputs:
+    - baro_calibration.pdf    Calibration plots
+    - Console output with recommended EKF2_PCOEF_THR / EKF2_PCOEF_TTAU values
+"""
+
+import argparse
+import os
+import sys
+
+import numpy as np
+
+try:
+    from pyulog import ULog
+except ImportError:
+    print("Error: pyulog not installed. Run: pip install pyulog", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+except ImportError:
+    print("Error: matplotlib not installed. Run: pip install matplotlib", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from scipy import signal as scipy_signal  # noqa: F401 — available for future use
+except ImportError:
+    print("Error: scipy not installed. Run: pip install scipy", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# ULog helpers
+# ---------------------------------------------------------------------------
+
+def get_topic(ulog, topic_name, multi_id=0):
+    """Return the first matching dataset for a topic name and multi_id."""
+    for d in ulog.data_list:
+        if d.name == topic_name and d.multi_id == multi_id:
+            return d
+    return None
+
+
+def get_param(ulog, name, default=None):
+    """Get an initial parameter value from the log."""
+    return ulog.initial_parameters.get(name, default)
+
+
+def us_to_seconds(ts_us, start_us):
+    """Convert microsecond timestamps to seconds relative to log start."""
+    return (ts_us.astype(np.int64) - np.int64(start_us)) / 1e6
+
+
+# ---------------------------------------------------------------------------
+# Flight phase detection
+# ---------------------------------------------------------------------------
+
+def detect_armed_period(ulog):
+    """Detect armed start/end times from vehicle_status or actuator_motors."""
+    start_us = ulog.start_timestamp
+
+    vstatus = get_topic(ulog, "vehicle_status")
+    if vstatus is not None and "arming_state" in vstatus.data:
+        ts = us_to_seconds(vstatus.data["timestamp"], start_us)
+        armed_idx = np.where(vstatus.data["arming_state"] == 2)[0]
+        if len(armed_idx) > 0:
+            return ts[armed_idx[0]], ts[armed_idx[-1]]
+
+    # Fallback: look for motor activity
+    motors = get_topic(ulog, "actuator_motors")
+    if motors is not None:
+        ts = us_to_seconds(motors.data["timestamp"], start_us)
+        active = np.zeros(len(ts), dtype=bool)
+        for i in range(12):
+            key = f"control[{i}]"
+            if key in motors.data:
+                active |= (motors.data[key] > 0.05)
+        active_idx = np.where(active)[0]
+        if len(active_idx) > 0:
+            return ts[active_idx[0]], ts[active_idx[-1]]
+
+    # Last resort: full log duration
+    return 0.0, (ulog.last_timestamp - start_us) / 1e6
+
+
+def find_hover_segment(armed_start, armed_end):
+    """Return middle 60% of armed time as the hover analysis window."""
+    duration = armed_end - armed_start
+    return armed_start + duration * 0.2, armed_end - duration * 0.2
+
+
+# ---------------------------------------------------------------------------
+# Data extraction
+# ---------------------------------------------------------------------------
+
+def extract_baro(ulog):
+    """Extract barometer altitude from vehicle_air_data."""
+    start_us = ulog.start_timestamp
+    vad = get_topic(ulog, "vehicle_air_data")
+    if vad is None:
+        return None
+    return {
+        "time_s": us_to_seconds(vad.data["timestamp"], start_us),
+        "alt_m": vad.data["baro_alt_meter"],
+    }
+
+
+def extract_range(ulog):
+    """Extract range sensor distance from distance_sensor."""
+    start_us = ulog.start_timestamp
+    dist = get_topic(ulog, "distance_sensor")
+    if dist is None:
+        return None
+    return {
+        "time_s": us_to_seconds(dist.data["timestamp"], start_us),
+        "distance_m": dist.data["current_distance"],
+    }
+
+
+def extract_thrust(ulog):
+    """Extract vertical thrust setpoint from vehicle_thrust_setpoint."""
+    start_us = ulog.start_timestamp
+    thr = get_topic(ulog, "vehicle_thrust_setpoint")
+    if thr is None:
+        return None
+    return {
+        "time_s": us_to_seconds(thr.data["timestamp"], start_us),
+        "thrust_z": thr.data["xyz[2]"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+def compute_baro_error(baro, range_data, armed_start):
+    """Compute baro altitude error relative to range sensor.
+
+    Both signals are aligned to a common time base (range sensor timestamps).
+    Baro altitude is zeroed at arm time so it represents change from ground.
+
+    Returns: dict with time_s, baro_error (baro - range, positive = baro reads
+    higher than truth), and the interpolated baro/range arrays.
+    """
+    baro_t, baro_alt = baro["time_s"], baro["alt_m"]
+    rng_t, rng_dist = range_data["time_s"], range_data["distance_m"]
+
+    # Zero baro at arm time
+    arm_baro = np.interp(armed_start, baro_t, baro_alt)
+    baro_zeroed = baro_alt - arm_baro
+
+    # Interpolate baro onto range sensor time base
+    baro_interp = np.interp(rng_t, baro_t, baro_zeroed)
+    error = baro_interp - rng_dist
+
+    return {
+        "time_s": rng_t,
+        "error": error,
+        "baro_alt": baro_interp,
+        "range_alt": rng_dist,
+        "baro_full_time_s": baro_t,
+        "baro_full_alt": baro_zeroed,
+    }
+
+
+def first_order_lpf(signal, time_s, tau):
+    """Apply a causal first-order low-pass filter with time constant tau.
+
+    Matches the AlphaFilter used in the EKF: alpha = dt / (dt + tau).
+    When tau=0, returns the input unchanged.
+    """
+    if tau <= 0 or len(signal) < 2:
+        return signal.copy()
+
+    out = np.empty_like(signal)
+    out[0] = signal[0]
+    for i in range(1, len(signal)):
+        dt = time_s[i] - time_s[i - 1]
+        if dt <= 0:
+            out[i] = out[i - 1]
+            continue
+        alpha = dt / (dt + tau)
+        out[i] = out[i - 1] + alpha * (signal[i] - out[i - 1])
+    return out
+
+
+def calibrate(baro_err, thrust_data, hover_start, hover_end):
+    """System identification for thrust-based baro compensation.
+
+    Fits: baro_error = K * LPF(thrust_magnitude, tau) + c
+
+    Sweeps over tau candidates and picks the one maximizing R^2.
+    Also computes cross-correlation to visualize the delay structure.
+
+    Returns dict with identified K, tau, cross-correlation data, sweep
+    results, and the recommended EKF parameters.
+    """
+    err_t = baro_err["time_s"]
+    err = baro_err["error"]
+
+    # Restrict to hover segment
+    hov = (err_t >= hover_start) & (err_t <= hover_end)
+    if hov.sum() < 20:
+        return None
+
+    err_t_hov = err_t[hov]
+    err_hov = err[hov]
+
+    # Interpolate thrust onto error timestamps and convert to upward magnitude
+    thrust_raw = np.interp(err_t_hov, thrust_data["time_s"],
+                           thrust_data["thrust_z"])
+    thrust_mag = np.clip(-thrust_raw, 0, 1)
+
+    # Detrend error (remove slow thermal / bias drift)
+    err_detrended = err_hov - np.polyval(
+        np.polyfit(err_t_hov, err_hov, 1), err_t_hov)
+    thrust_detrended = thrust_mag - np.mean(thrust_mag)
+
+    err_var = np.var(err_detrended)
+    if err_var < 1e-10:
+        return None
+
+    result = {
+        "hover_time": err_t_hov,
+        "hover_error": err_hov,
+        "thrust_mag": thrust_mag,
+    }
+
+    # --- Cross-correlation ---
+    dt_median = np.median(np.diff(err_t_hov))
+    if dt_median > 0:
+        max_lag = min(int(2.0 / dt_median), len(err_detrended) // 2)
+        if max_lag > 5:
+            xcorr = np.correlate(err_detrended, thrust_detrended, "full")
+            mid = len(thrust_detrended) - 1
+            lags = (np.arange(len(xcorr)) - mid) * dt_median
+            norm = np.sqrt(np.sum(err_detrended**2) *
+                           np.sum(thrust_detrended**2))
+            if norm > 0:
+                xcorr = xcorr / norm
+            window = (lags >= -2.0) & (lags <= 2.0)
+            result["xcorr_lags_s"] = lags[window]
+            result["xcorr_values"] = xcorr[window]
+            peak_idx = np.argmax(np.abs(xcorr[window]))
+            result["xcorr_peak_lag_s"] = float(lags[window][peak_idx])
+            result["xcorr_peak_value"] = float(xcorr[window][peak_idx])
+
+    # --- Grid search over time constants ---
+    tau_candidates = np.concatenate([
+        [0.0],
+        np.arange(0.02, 0.2, 0.02),
+        np.arange(0.2, 1.01, 0.05),
+    ])
+
+    sweep_tau, sweep_r2, sweep_K, sweep_rmse = [], [], [], []
+
+    for tau in tau_candidates:
+        thrust_filt = first_order_lpf(thrust_mag, err_t_hov, tau)
+        thrust_filt_centered = thrust_filt - np.mean(thrust_filt)
+
+        if np.var(thrust_filt_centered) < 1e-10:
+            continue
+
+        # Least-squares: err_detrended = K * thrust_filt_centered
+        K = np.sum(err_detrended * thrust_filt_centered) / \
+            np.sum(thrust_filt_centered**2)
+        residual = err_detrended - K * thrust_filt_centered
+        r2 = 1.0 - np.var(residual) / err_var
+
+        sweep_tau.append(float(tau))
+        sweep_r2.append(float(r2))
+        sweep_K.append(float(K))
+        sweep_rmse.append(float(np.sqrt(np.mean(residual**2))))
+
+    if not sweep_tau:
+        return None
+
+    result["sweep_tau"] = np.array(sweep_tau)
+    result["sweep_r2"] = np.array(sweep_r2)
+    result["sweep_K"] = np.array(sweep_K)
+    result["sweep_rmse"] = np.array(sweep_rmse)
+
+    # Best fit
+    best_idx = int(np.argmax(sweep_r2))
+    result["best_tau"] = sweep_tau[best_idx]
+    result["best_K"] = sweep_K[best_idx]
+    result["best_r2"] = sweep_r2[best_idx]
+    result["best_rmse"] = sweep_rmse[best_idx]
+
+    # No-lag baseline for comparison
+    result["nolag_K"] = sweep_K[0] if sweep_tau[0] == 0.0 else 0.0
+    result["nolag_r2"] = sweep_r2[0] if sweep_tau[0] == 0.0 else 0.0
+
+    # Compensated timeseries (for plotting)
+    best_filt = first_order_lpf(thrust_mag, err_t_hov, result["best_tau"])
+    result["compensated_error"] = err_hov - result["best_K"] * best_filt
+
+    # Recommended EKF parameters:
+    #   baro_error = K * thrust  =>  to cancel, apply correction = -K * thrust
+    #   EKF does: baro_alt += pcoef_thr * thrust
+    #   So pcoef_thr = -K
+    result["recommended_pcoef_thr"] = -result["best_K"]
+    result["recommended_pcoef_ttau"] = result["best_tau"]
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+def plot_overview(baro_err, thrust_data, armed_start, armed_end,
+                  hover_start, hover_end):
+    """Page 1: Baro vs range altitude and baro error with thrust overlay."""
+    fig, axes = plt.subplots(3, 1, figsize=(14, 10), sharex=True)
+    fig.suptitle("Baro Altitude vs Range Sensor", fontsize=14, fontweight="bold")
+
+    t = baro_err["time_s"]
+    err = baro_err["error"]
+
+    # Panel 1: Altitude comparison
+    ax = axes[0]
+    ax.plot(t, baro_err["range_alt"], label="Range sensor (ground truth)",
+            color="tab:green", linewidth=1.2)
+    ax.plot(baro_err["baro_full_time_s"], baro_err["baro_full_alt"],
+            label="Baro alt (zeroed at arm)", color="tab:red",
+            linewidth=1.2, alpha=0.85)
+    ax.axvspan(armed_start, armed_end, alpha=0.04, color="green", label="Armed")
+    ax.axvspan(hover_start, hover_end, alpha=0.08, color="blue",
+               label="Hover window")
+    ax.set_ylabel("Altitude [m]")
+    ax.legend(loc="upper left", fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Panel 2: Baro error
+    ax = axes[1]
+    ax.plot(t, err, color="tab:red", linewidth=0.8, label="Baro error (baro - range)")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--")
+    ax.axvspan(hover_start, hover_end, alpha=0.08, color="blue")
+    ax.set_ylabel("Baro Error [m]")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Panel 3: Thrust
+    ax = axes[2]
+    if thrust_data is not None:
+        thr_t = thrust_data["time_s"]
+        thr_mag = np.clip(-thrust_data["thrust_z"], 0, 1)
+        ax.plot(thr_t, thr_mag, color="tab:orange", linewidth=0.8,
+                label="Thrust magnitude")
+        ax.axvspan(hover_start, hover_end, alpha=0.08, color="blue")
+    ax.set_ylabel("Thrust [0-1]")
+    ax.set_xlabel("Time [s]")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_calibration(calib):
+    """Page 2: Calibration results — xcorr, tau sweep, before/after, params."""
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10))
+    fig.suptitle("Thrust Compensation Calibration", fontsize=14,
+                 fontweight="bold")
+
+    # Top-left: Cross-correlation
+    ax = axes[0, 0]
+    if "xcorr_lags_s" in calib:
+        ax.plot(calib["xcorr_lags_s"] * 1000, calib["xcorr_values"],
+                color="tab:blue", linewidth=1.0)
+        peak_lag = calib["xcorr_peak_lag_s"]
+        peak_val = calib["xcorr_peak_value"]
+        ax.axvline(peak_lag * 1000, color="tab:red", linestyle="--",
+                   linewidth=0.8,
+                   label=f"Peak: {peak_lag*1000:.0f} ms (r={peak_val:.2f})")
+        ax.axvline(0, color="k", linewidth=0.5, linestyle=":")
+        ax.legend(fontsize=9)
+    ax.set_xlabel("Lag [ms] (positive = error lags thrust)")
+    ax.set_ylabel("Cross-correlation")
+    ax.set_title("Cross-Correlation: Thrust vs Baro Error")
+    ax.grid(True, alpha=0.3)
+
+    # Top-right: R^2 vs tau
+    ax = axes[0, 1]
+    if "sweep_tau" in calib:
+        ax.plot(calib["sweep_tau"], calib["sweep_r2"],
+                "o-", color="tab:green", markersize=3, linewidth=1.0)
+        ax.axvline(calib["best_tau"], color="tab:red", linestyle="--",
+                   linewidth=0.8,
+                   label=f"Best: tau={calib['best_tau']:.2f}s "
+                         f"(R\u00b2={calib['best_r2']:.3f})")
+        ax.legend(fontsize=9)
+    ax.set_xlabel("Time constant tau [s]")
+    ax.set_ylabel("R\u00b2")
+    ax.set_title("Model Fit vs Filter Time Constant")
+    ax.grid(True, alpha=0.3)
+
+    # Bottom-left: Before/after compensation
+    ax = axes[1, 0]
+    if "hover_time" in calib:
+        t = calib["hover_time"]
+        ax.plot(t, calib["hover_error"], color="tab:red", linewidth=0.8,
+                alpha=0.7, label="Raw baro error")
+        ax.plot(t, calib["compensated_error"], color="tab:blue", linewidth=0.8,
+                label=f"Compensated (K={calib['best_K']:.2f}, "
+                      f"tau={calib['best_tau']:.2f}s)")
+        ax.axhline(0, color="k", linewidth=0.5, linestyle="--")
+        ax.legend(fontsize=9)
+    ax.set_xlabel("Time [s]")
+    ax.set_ylabel("Baro Error [m]")
+    ax.set_title("Compensation Effect (Hover Segment)")
+    ax.grid(True, alpha=0.3)
+
+    # Bottom-right: Recommended parameters
+    ax = axes[1, 1]
+    ax.axis("off")
+    lines = [
+        "Recommended Parameters",
+        "",
+        f"  EKF2_PCOEF_THR  = {calib['recommended_pcoef_thr']:+.2f}  m",
+        f"  EKF2_PCOEF_TTAU = {calib['recommended_pcoef_ttau']:.2f}  s",
+        "",
+        f"  Identified gain K  = {calib['best_K']:.3f} m/unit",
+        f"  Time constant tau  = {calib['best_tau']:.3f} s",
+        f"  Model R\u00b2           = {calib['best_r2']:.3f}",
+        f"  Residual RMSE      = {calib['best_rmse']:.3f} m",
+        "",
+        f"  No-lag model R\u00b2    = {calib['nolag_r2']:.3f}",
+        f"  R\u00b2 improvement     = {calib['best_r2'] - calib['nolag_r2']:.3f}",
+    ]
+    if "xcorr_peak_lag_s" in calib:
+        lines.append(
+            f"  Cross-corr peak    = {calib['xcorr_peak_lag_s']*1000:.0f} ms")
+    ax.text(0.1, 0.95, "\n".join(lines), transform=ax.transAxes,
+            fontsize=11, verticalalignment="top", family="monospace",
+            bbox=dict(boxstyle="round,pad=0.5", facecolor="#f0f0f0",
+                      edgecolor="#cccccc"))
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_scatter(baro_err, thrust_data, calib, hover_start, hover_end):
+    """Page 3: Error vs thrust scatter — raw and compensated."""
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+    fig.suptitle("Baro Error vs Thrust (Hover Segment)", fontsize=14,
+                 fontweight="bold")
+
+    t = baro_err["time_s"]
+    err = baro_err["error"]
+    hov = (t >= hover_start) & (t <= hover_end)
+
+    thrust_interp = np.interp(t[hov], thrust_data["time_s"],
+                              thrust_data["thrust_z"])
+    err_hov = err[hov]
+
+    # Raw
+    ax = axes[0]
+    ax.scatter(thrust_interp, err_hov, s=3, alpha=0.4, color="tab:orange")
+    z = np.polyfit(thrust_interp, err_hov, 1)
+    x_fit = np.linspace(thrust_interp.min(), thrust_interp.max(), 50)
+    ax.plot(x_fit, np.polyval(z, x_fit), "k--", linewidth=1.2)
+    r_val = float(np.corrcoef(thrust_interp, err_hov)[0, 1])
+    ax.set_xlabel("Thrust Z setpoint")
+    ax.set_ylabel("Baro Error [m]")
+    ax.set_title(f"Raw\nr = {r_val:.3f},  slope = {z[0]:.2f} m/unit")
+    ax.grid(True, alpha=0.3)
+
+    # Compensated
+    ax = axes[1]
+    thrust_mag = np.clip(-thrust_interp, 0, 1)
+    thrust_filt = first_order_lpf(thrust_mag, t[hov], calib["best_tau"])
+    comp_err = err_hov - calib["best_K"] * thrust_filt
+    ax.scatter(thrust_interp, comp_err, s=3, alpha=0.4, color="tab:blue")
+    z = np.polyfit(thrust_interp, comp_err, 1)
+    ax.plot(x_fit, np.polyval(z, x_fit), "k--", linewidth=1.2)
+    r_val = float(np.corrcoef(thrust_interp, comp_err)[0, 1])
+    ax.set_xlabel("Thrust Z setpoint")
+    ax.set_ylabel("Compensated Error [m]")
+    ax.set_title(f"After Compensation "
+                 f"(PCOEF_THR={calib['recommended_pcoef_thr']:+.2f})\n"
+                 f"r = {r_val:.3f},  slope = {z[0]:.2f} m/unit")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.3)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Calibrate EKF2 barometer thrust compensation parameters")
+    parser.add_argument("ulog_file", help="Path to .ulg flight log")
+    parser.add_argument("--output-dir", "-o", default=None,
+                        help="Output directory (default: same dir as log)")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.ulog_file):
+        print(f"Error: file not found: {args.ulog_file}", file=sys.stderr)
+        sys.exit(1)
+
+    output_dir = args.output_dir or os.path.dirname(
+        os.path.abspath(args.ulog_file))
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Load log
+    print(f"Loading {args.ulog_file} ...")
+    ulog = ULog(args.ulog_file)
+    duration = (ulog.last_timestamp - ulog.start_timestamp) / 1e6
+    print(f"  Duration: {duration:.1f} s")
+
+    # Print relevant parameters
+    print("\nParameters:")
+    for p in ["EKF2_HGT_REF", "EKF2_BARO_CTRL", "EKF2_BARO_NOISE",
+              "EKF2_PCOEF_THR", "EKF2_PCOEF_TTAU"]:
+        val = get_param(ulog, p)
+        if val is not None:
+            print(f"  {p:24s} = {val}")
+
+    # Detect flight phases
+    armed_start, armed_end = detect_armed_period(ulog)
+    hover_start, hover_end = find_hover_segment(armed_start, armed_end)
+    print(f"\nArmed:  {armed_start:.1f}s - {armed_end:.1f}s")
+    print(f"Hover:  {hover_start:.1f}s - {hover_end:.1f}s")
+
+    # Extract data
+    baro = extract_baro(ulog)
+    range_data = extract_range(ulog)
+    thrust_data = extract_thrust(ulog)
+
+    if baro is None:
+        print("Error: no barometer data (vehicle_air_data) in log",
+              file=sys.stderr)
+        sys.exit(1)
+    if range_data is None:
+        print("Error: no range sensor data (distance_sensor) in log.\n"
+              "A range sensor is required as ground truth for calibration.",
+              file=sys.stderr)
+        sys.exit(1)
+    if thrust_data is None:
+        print("Error: no thrust data (vehicle_thrust_setpoint) in log",
+              file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\n  Baro samples:   {len(baro['time_s'])}")
+    print(f"  Range samples:  {len(range_data['time_s'])}")
+    print(f"  Thrust samples: {len(thrust_data['time_s'])}")
+
+    # Compute baro error
+    baro_err = compute_baro_error(baro, range_data, armed_start)
+
+    hov = ((baro_err["time_s"] >= hover_start) &
+           (baro_err["time_s"] <= hover_end))
+    if hov.sum() < 20:
+        print("Error: not enough data in hover segment", file=sys.stderr)
+        sys.exit(1)
+
+    err_hov = baro_err["error"][hov]
+    print(f"\nBaro error during hover:")
+    print(f"  Mean:  {np.mean(err_hov):+.3f} m")
+    print(f"  Std:   {np.std(err_hov):.3f} m")
+
+    # Thrust correlation
+    thrust_interp = np.interp(baro_err["time_s"][hov],
+                              thrust_data["time_s"], thrust_data["thrust_z"])
+    r_thrust = float(np.corrcoef(thrust_interp, err_hov)[0, 1])
+    print(f"  Thrust correlation: r = {r_thrust:+.3f}"
+          f"  ({'strong' if abs(r_thrust) > 0.6 else 'moderate' if abs(r_thrust) > 0.3 else 'weak'})")
+
+    # Calibrate
+    print("\nRunning calibration ...")
+    calib = calibrate(baro_err, thrust_data, hover_start, hover_end)
+
+    if calib is None:
+        print("Calibration failed: insufficient data or thrust variation.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\n  Identified gain K       = {calib['best_K']:.3f} m/unit thrust")
+    print(f"  Time constant tau       = {calib['best_tau']:.3f} s")
+    print(f"  Model R\u00b2               = {calib['best_r2']:.3f}")
+    print(f"  Residual RMSE           = {calib['best_rmse']:.3f} m")
+    if "xcorr_peak_lag_s" in calib:
+        print(f"  Cross-correlation peak  = {calib['xcorr_peak_lag_s']*1000:.0f} ms")
+
+    improvement = calib["best_r2"] - calib["nolag_r2"]
+    print(f"  No-lag R\u00b2              = {calib['nolag_r2']:.3f}")
+    print(f"  R\u00b2 improvement from lag = {improvement:+.3f}")
+
+    print(f"\n{'='*50}")
+    print(f"  RECOMMENDED PARAMETERS")
+    print(f"{'='*50}")
+    print(f"  EKF2_PCOEF_THR  = {calib['recommended_pcoef_thr']:+.2f}")
+    print(f"  EKF2_PCOEF_TTAU = {calib['recommended_pcoef_ttau']:.2f}")
+    print(f"{'='*50}")
+
+    if calib["best_r2"] < 0.1:
+        print(f"\nNote: Low R\u00b2 ({calib['best_r2']:.3f}) suggests thrust is not "
+              "the dominant baro error source. Compensation may not help much.")
+    if improvement < 0.01:
+        print(f"\nNote: The lag filter provides negligible improvement over "
+              "tau=0. You may set EKF2_PCOEF_TTAU = 0.")
+
+    # Generate plots
+    print("\nGenerating plots ...")
+    figures = [
+        plot_overview(baro_err, thrust_data, armed_start, armed_end,
+                      hover_start, hover_end),
+        plot_calibration(calib),
+        plot_scatter(baro_err, thrust_data, calib, hover_start, hover_end),
+    ]
+
+    pdf_path = os.path.join(output_dir, "baro_calibration.pdf")
+    with PdfPages(pdf_path) as pdf:
+        for fig in figures:
+            pdf.savefig(fig)
+            plt.close(fig)
+    print(f"  Saved: {pdf_path}")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -203,16 +203,36 @@ void Ekf::stopBaroHgtFusion()
 }
 
 #if defined(CONFIG_EKF2_BARO_COMPENSATION)
-float Ekf::compensateBaroAltitude(const imuSample &imu_sample, const baroSample &baro_sample) const
+float Ekf::compensateBaroAltitude(const imuSample &imu_sample, const baroSample &baro_sample)
 {
 	float baro_alt = baro_sample.hgt;
 
 	// Propwash-induced static pressure compensation for multirotor vehicles.
 	// Corrects for the pressure change at the baro sensor caused by rotor downwash,
 	// which is proportional to collective thrust magnitude.
-	// Uses thrust captured at baro sample time to avoid phase delay from EKF ring buffer.
+	// A first-order lag filter on thrust models the delay between a thrust setpoint
+	// change and the resulting pressure change at the baro sensor (motor spin-up,
+	// propwash development, sensor response). The time constant is set via EKF2_PCOEF_TTAU.
 	if (!_control_status.flags.fixed_wing && (fabsf(_params.ekf2_pcoef_thr) > FLT_EPSILON)) {
-		baro_alt += _params.ekf2_pcoef_thr * baro_sample.thrust_magnitude;
+		float thrust = baro_sample.thrust_magnitude;
+
+		if (_params.ekf2_pcoef_thr_tau > FLT_EPSILON) {
+			if (_baro_thrust_lpf_last_us == 0 || baro_sample.reset) {
+				_baro_thrust_lpf.reset(thrust);
+
+			} else {
+				const float dt = math::constrain(
+							 static_cast<float>(baro_sample.time_us - _baro_thrust_lpf_last_us) * 1e-6f,
+							 0.001f, 0.5f);
+				_baro_thrust_lpf.setParameters(dt, _params.ekf2_pcoef_thr_tau);
+				_baro_thrust_lpf.update(thrust);
+			}
+
+			_baro_thrust_lpf_last_us = baro_sample.time_us;
+			thrust = _baro_thrust_lpf.getState();
+		}
+
+		baro_alt += _params.ekf2_pcoef_thr * thrust;
 	}
 
 	// Airspeed-induced static pressure position error compensation

--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -235,6 +235,7 @@ float Ekf::compensateBaroAltitude(const imuSample &imu_sample, const baroSample 
 		baro_alt += _params.ekf2_pcoef_thr * thrust;
 	}
 
+#if defined(CONFIG_EKF2_WIND)
 	// Airspeed-induced static pressure position error compensation
 	if (_control_status.flags.wind && isLocalHorizontalPositionValid()) {
 		// calculate static pressure error = Pmeas - Ptruth
@@ -264,6 +265,7 @@ float Ekf::compensateBaroAltitude(const imuSample &imu_sample, const baroSample 
 		// correct baro measurement using pressure error estimate and assuming sea level gravity
 		baro_alt += pstatic_err / (_air_density * CONSTANTS_ONE_G);
 	}
+#endif // CONFIG_EKF2_WIND
 
 	return baro_alt;
 }

--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -52,7 +52,7 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 	if (_baro_buffer && _baro_buffer->pop_first_older_than(imu_sample.time_us, &baro_sample)) {
 
 #if defined(CONFIG_EKF2_BARO_COMPENSATION)
-		const float measurement = compensateBaroForDynamicPressure(imu_sample, baro_sample.hgt);
+		const float measurement = compensateBaroAltitude(imu_sample, baro_sample.hgt);
 #else
 		const float measurement = baro_sample.hgt;
 #endif
@@ -203,8 +203,18 @@ void Ekf::stopBaroHgtFusion()
 }
 
 #if defined(CONFIG_EKF2_BARO_COMPENSATION)
-float Ekf::compensateBaroForDynamicPressure(const imuSample &imu_sample, const float baro_alt_uncompensated) const
+float Ekf::compensateBaroAltitude(const imuSample &imu_sample, const float baro_alt_uncompensated) const
 {
+	float baro_alt = baro_alt_uncompensated;
+
+	// Propwash-induced static pressure compensation for multirotor vehicles.
+	// Corrects for the pressure change at the baro sensor caused by rotor downwash,
+	// which is proportional to collective thrust magnitude.
+	if (!_control_status.flags.fixed_wing && (fabsf(_params.ekf2_pcoef_thr) > FLT_EPSILON)) {
+		baro_alt += _params.ekf2_pcoef_thr * _thrust_magnitude;
+	}
+
+	// Airspeed-induced static pressure position error compensation
 	if (_control_status.flags.wind && isLocalHorizontalPositionValid()) {
 		// calculate static pressure error = Pmeas - Ptruth
 		// model position error sensitivity as a body fixed ellipse with a different scale in the positive and
@@ -231,10 +241,9 @@ float Ekf::compensateBaroForDynamicPressure(const imuSample &imu_sample, const f
 		const float pstatic_err = 0.5f * _air_density * (airspeed_squared.dot(K_pstatic_coef));
 
 		// correct baro measurement using pressure error estimate and assuming sea level gravity
-		return baro_alt_uncompensated + pstatic_err / (_air_density * CONSTANTS_ONE_G);
+		baro_alt += pstatic_err / (_air_density * CONSTANTS_ONE_G);
 	}
 
-	// otherwise return the uncorrected baro measurement
-	return baro_alt_uncompensated;
+	return baro_alt;
 }
 #endif // CONFIG_EKF2_BARO_COMPENSATION

--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -52,7 +52,7 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 	if (_baro_buffer && _baro_buffer->pop_first_older_than(imu_sample.time_us, &baro_sample)) {
 
 #if defined(CONFIG_EKF2_BARO_COMPENSATION)
-		const float measurement = compensateBaroAltitude(imu_sample, baro_sample.hgt);
+		const float measurement = compensateBaroAltitude(imu_sample, baro_sample);
 #else
 		const float measurement = baro_sample.hgt;
 #endif
@@ -203,15 +203,16 @@ void Ekf::stopBaroHgtFusion()
 }
 
 #if defined(CONFIG_EKF2_BARO_COMPENSATION)
-float Ekf::compensateBaroAltitude(const imuSample &imu_sample, const float baro_alt_uncompensated) const
+float Ekf::compensateBaroAltitude(const imuSample &imu_sample, const baroSample &baro_sample) const
 {
-	float baro_alt = baro_alt_uncompensated;
+	float baro_alt = baro_sample.hgt;
 
 	// Propwash-induced static pressure compensation for multirotor vehicles.
 	// Corrects for the pressure change at the baro sensor caused by rotor downwash,
 	// which is proportional to collective thrust magnitude.
+	// Uses thrust captured at baro sample time to avoid phase delay from EKF ring buffer.
 	if (!_control_status.flags.fixed_wing && (fabsf(_params.ekf2_pcoef_thr) > FLT_EPSILON)) {
-		baro_alt += _params.ekf2_pcoef_thr * _thrust_magnitude;
+		baro_alt += _params.ekf2_pcoef_thr * baro_sample.thrust_magnitude;
 	}
 
 	// Airspeed-induced static pressure position error compensation

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -324,7 +324,8 @@ struct parameters {
 	float ekf2_pcoef_yn{0.0f};    // (-)
 	float ekf2_pcoef_z{0.0f};     // (-)
 
-	float ekf2_pcoef_thr{0.0f};  // propwash baro altitude correction per unit thrust (m)
+	float ekf2_pcoef_thr{0.0f};      // propwash baro altitude correction per unit thrust (m)
+	float ekf2_pcoef_thr_tau{0.0f};  // first-order lag time constant for thrust compensation (s)
 
 	// upper limit on airspeed used for correction  (m/s**2)
 	float ekf2_aspd_max{20.0f};

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -213,9 +213,10 @@ struct magSample {
 };
 
 struct baroSample {
-	uint64_t    time_us{};  ///< timestamp of the measurement (uSec)
-	float       hgt{};      ///< pressure altitude above sea level (m)
+	uint64_t    time_us{};              ///< timestamp of the measurement (uSec)
+	float       hgt{};                  ///< pressure altitude above sea level (m)
 	bool        reset{false};
+	float       thrust_magnitude{0.f};  ///< normalized collective thrust [0, 1] captured at sample time for propwash compensation
 };
 
 struct airspeedSample {

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -317,6 +317,10 @@ struct parameters {
 	float ekf2_gnd_max_hgt{0.5f};           ///< Height above ground at which baro ground effect becomes insignificant (m)
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	float ekf2_pcoef_thr{0.0f};      // propwash baro altitude correction per unit thrust (m)
+	float ekf2_pcoef_thr_tau{0.0f};  // first-order lag time constant for thrust compensation (s)
+
+#  if defined(CONFIG_EKF2_WIND)
 	// static barometer pressure position error coefficient along body axes
 	float ekf2_pcoef_xp{0.0f};    // (-)
 	float ekf2_pcoef_xn{0.0f};    // (-)
@@ -324,11 +328,9 @@ struct parameters {
 	float ekf2_pcoef_yn{0.0f};    // (-)
 	float ekf2_pcoef_z{0.0f};     // (-)
 
-	float ekf2_pcoef_thr{0.0f};      // propwash baro altitude correction per unit thrust (m)
-	float ekf2_pcoef_thr_tau{0.0f};  // first-order lag time constant for thrust compensation (s)
-
 	// upper limit on airspeed used for correction  (m/s**2)
 	float ekf2_aspd_max{20.0f};
+#  endif // CONFIG_EKF2_WIND
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -323,6 +323,8 @@ struct parameters {
 	float ekf2_pcoef_yn{0.0f};    // (-)
 	float ekf2_pcoef_z{0.0f};     // (-)
 
+	float ekf2_pcoef_thr{0.0f};  // propwash baro altitude correction per unit thrust (m)
+
 	// upper limit on airspeed used for correction  (m/s**2)
 	float ekf2_aspd_max{20.0f};
 # endif // CONFIG_EKF2_BARO_COMPENSATION

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -971,7 +971,7 @@ private:
 	void updateGroundEffect();
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
-	float compensateBaroForDynamicPressure(const imuSample &imu_sample, float baro_alt_uncompensated) const;
+	float compensateBaroAltitude(const imuSample &imu_sample, float baro_alt_uncompensated) const;
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 
 #endif // CONFIG_EKF2_BAROMETER

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -971,7 +971,7 @@ private:
 	void updateGroundEffect();
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
-	float compensateBaroAltitude(const imuSample &imu_sample, float baro_alt_uncompensated) const;
+	float compensateBaroAltitude(const imuSample &imu_sample, const baroSample &baro_sample) const;
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 
 #endif // CONFIG_EKF2_BAROMETER

--- a/src/modules/ekf2/EKF/ekf.h
+++ b/src/modules/ekf2/EKF/ekf.h
@@ -612,6 +612,11 @@ private:
 
 	HeightBiasEstimator _baro_b_est{HeightSensor::BARO, _height_sensor_ref};
 
+# if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	AlphaFilter<float> _baro_thrust_lpf{};   ///< first-order lag filter on thrust for propwash compensation
+	uint64_t _baro_thrust_lpf_last_us{0};    ///< timestamp of last thrust filter update (uSec)
+# endif // CONFIG_EKF2_BARO_COMPENSATION
+
 #endif // CONFIG_EKF2_BAROMETER
 
 #if defined(CONFIG_EKF2_MAGNETOMETER)
@@ -971,7 +976,7 @@ private:
 	void updateGroundEffect();
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
-	float compensateBaroAltitude(const imuSample &imu_sample, const baroSample &baro_sample) const;
+	float compensateBaroAltitude(const imuSample &imu_sample, const baroSample &baro_sample);
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 
 #endif // CONFIG_EKF2_BAROMETER

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -211,6 +211,11 @@ public:
 	// set air density used by the multi-rotor specific drag force fusion
 	void set_air_density(float air_density) { _air_density = air_density; }
 
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	// set normalized collective thrust magnitude [0, 1] for propwash baro compensation
+	void set_thrust_magnitude(float thrust_magnitude) { _thrust_magnitude = thrust_magnitude; }
+#endif // CONFIG_EKF2_BARO_COMPENSATION
+
 	bool isOnlyActiveSourceOfHorizontalAiding(bool aiding_flag) const;
 	bool isOnlyActiveSourceOfHorizontalPositionAiding(bool aiding_flag) const;
 	bool isOnlyActiveSourceOfHorizontalVelocityAiding(bool aiding_flag) const;
@@ -385,6 +390,10 @@ protected:
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 
 	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};		// air density (kg/m**3)
+
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	float _thrust_magnitude {0.f};		// normalized collective thrust magnitude [0, 1] for propwash baro compensation
+#endif // CONFIG_EKF2_BARO_COMPENSATION
 
 	bool _imu_updated{false};      // true if the ekf should update (completed downsampling process)
 	bool _initialised{false};      // true if the ekf interface instance (data buffering) is initialized

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -211,11 +211,6 @@ public:
 	// set air density used by the multi-rotor specific drag force fusion
 	void set_air_density(float air_density) { _air_density = air_density; }
 
-#if defined(CONFIG_EKF2_BARO_COMPENSATION)
-	// set normalized collective thrust magnitude [0, 1] for propwash baro compensation
-	void set_thrust_magnitude(float thrust_magnitude) { _thrust_magnitude = thrust_magnitude; }
-#endif // CONFIG_EKF2_BARO_COMPENSATION
-
 	bool isOnlyActiveSourceOfHorizontalAiding(bool aiding_flag) const;
 	bool isOnlyActiveSourceOfHorizontalPositionAiding(bool aiding_flag) const;
 	bool isOnlyActiveSourceOfHorizontalVelocityAiding(bool aiding_flag) const;
@@ -390,10 +385,6 @@ protected:
 #endif // CONFIG_EKF2_OPTICAL_FLOW
 
 	float _air_density{atmosphere::kAirDensitySeaLevelStandardAtmos};		// air density (kg/m**3)
-
-#if defined(CONFIG_EKF2_BARO_COMPENSATION)
-	float _thrust_magnitude {0.f};		// normalized collective thrust magnitude [0, 1] for propwash baro compensation
-#endif // CONFIG_EKF2_BARO_COMPENSATION
 
 	bool _imu_updated{false};      // true if the ekf should update (completed downsampling process)
 	bool _initialised{false};      // true if the ekf interface instance (data buffering) is initialized

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -103,14 +103,16 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_gnd_eff_dz(_params->ekf2_gnd_eff_dz),
 	_param_ekf2_gnd_max_hgt(_params->ekf2_gnd_max_hgt),
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	_param_ekf2_pcoef_thr(_params->ekf2_pcoef_thr),
+	_param_ekf2_pcoef_thr_tau(_params->ekf2_pcoef_thr_tau),
+#  if defined(CONFIG_EKF2_WIND)
 	_param_ekf2_aspd_max(_params->ekf2_aspd_max),
 	_param_ekf2_pcoef_xp(_params->ekf2_pcoef_xp),
 	_param_ekf2_pcoef_xn(_params->ekf2_pcoef_xn),
 	_param_ekf2_pcoef_yp(_params->ekf2_pcoef_yp),
 	_param_ekf2_pcoef_yn(_params->ekf2_pcoef_yn),
 	_param_ekf2_pcoef_z(_params->ekf2_pcoef_z),
-	_param_ekf2_pcoef_thr(_params->ekf2_pcoef_thr),
-	_param_ekf2_pcoef_thr_tau(_params->ekf2_pcoef_thr_tau),
+#  endif // CONFIG_EKF2_WIND
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 #if defined(CONFIG_EKF2_AIRSPEED)

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -2180,21 +2180,20 @@ void EKF2::UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps)
 
 		_ekf.set_air_density(airdata.rho);
 
+		float thrust_magnitude = 0.f;
+
 #if defined(CONFIG_EKF2_BARO_COMPENSATION)
 		vehicle_thrust_setpoint_s thrust_sp;
 
 		if (_vehicle_thrust_setpoint_sub.copy(&thrust_sp)) {
 			if (hrt_elapsed_time(&thrust_sp.timestamp) < 500_ms) {
-				_ekf.set_thrust_magnitude(math::constrain(-thrust_sp.xyz[2], 0.f, 1.f));
-
-			} else {
-				_ekf.set_thrust_magnitude(0.f);
+				thrust_magnitude = math::constrain(-thrust_sp.xyz[2], 0.f, 1.f);
 			}
 		}
 
 #endif // CONFIG_EKF2_BARO_COMPENSATION
 
-		_ekf.setBaroData(baroSample{airdata.timestamp_sample, airdata.baro_alt_meter, reset});
+		_ekf.setBaroData(baroSample{airdata.timestamp_sample, airdata.baro_alt_meter, reset, thrust_magnitude});
 
 		ekf2_timestamps.vehicle_air_data_timestamp_rel = (int16_t)((int64_t)airdata.timestamp / 100 -
 				(int64_t)ekf2_timestamps.timestamp / 100);

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -109,6 +109,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_pcoef_yp(_params->ekf2_pcoef_yp),
 	_param_ekf2_pcoef_yn(_params->ekf2_pcoef_yn),
 	_param_ekf2_pcoef_z(_params->ekf2_pcoef_z),
+	_param_ekf2_pcoef_thr(_params->ekf2_pcoef_thr),
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 #if defined(CONFIG_EKF2_AIRSPEED)
@@ -2178,6 +2179,20 @@ void EKF2::UpdateBaroSample(ekf2_timestamps_s &ekf2_timestamps)
 		}
 
 		_ekf.set_air_density(airdata.rho);
+
+#if defined(CONFIG_EKF2_BARO_COMPENSATION)
+		vehicle_thrust_setpoint_s thrust_sp;
+
+		if (_vehicle_thrust_setpoint_sub.copy(&thrust_sp)) {
+			if (hrt_elapsed_time(&thrust_sp.timestamp) < 500_ms) {
+				_ekf.set_thrust_magnitude(math::constrain(-thrust_sp.xyz[2], 0.f, 1.f));
+
+			} else {
+				_ekf.set_thrust_magnitude(0.f);
+			}
+		}
+
+#endif // CONFIG_EKF2_BARO_COMPENSATION
 
 		_ekf.setBaroData(baroSample{airdata.timestamp_sample, airdata.baro_alt_meter, reset});
 

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -110,6 +110,7 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_pcoef_yn(_params->ekf2_pcoef_yn),
 	_param_ekf2_pcoef_z(_params->ekf2_pcoef_z),
 	_param_ekf2_pcoef_thr(_params->ekf2_pcoef_thr),
+	_param_ekf2_pcoef_thr_tau(_params->ekf2_pcoef_thr_tau),
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 #if defined(CONFIG_EKF2_AIRSPEED)

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -550,6 +550,9 @@ private:
 		(ParamExtFloat<px4::params::EKF2_GND_MAX_HGT>) _param_ekf2_gnd_max_hgt,
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
+		(ParamExtFloat<px4::params::EKF2_PCOEF_THR>) _param_ekf2_pcoef_thr,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_TTAU>) _param_ekf2_pcoef_thr_tau,
+#  if defined(CONFIG_EKF2_WIND)
 		// Corrections for static pressure position error where Ps_error = Ps_meas - Ps_truth
 		(ParamExtFloat<px4::params::EKF2_ASPD_MAX>) _param_ekf2_aspd_max,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_XP>) _param_ekf2_pcoef_xp,
@@ -557,8 +560,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_PCOEF_YP>) _param_ekf2_pcoef_yp,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_YN>) _param_ekf2_pcoef_yn,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_Z>) _param_ekf2_pcoef_z,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_THR>) _param_ekf2_pcoef_thr,
-		(ParamExtFloat<px4::params::EKF2_PCOEF_TTAU>) _param_ekf2_pcoef_thr_tau,
+#  endif // CONFIG_EKF2_WIND
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -558,6 +558,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_PCOEF_YN>) _param_ekf2_pcoef_yn,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_Z>) _param_ekf2_pcoef_z,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_THR>) _param_ekf2_pcoef_thr,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_TTAU>) _param_ekf2_pcoef_thr_tau,
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -86,6 +86,7 @@
 #include <uORB/topics/vehicle_local_position.h>
 #include <uORB/topics/vehicle_odometry.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_thrust_setpoint.h>
 #include <uORB/topics/yaw_estimator_status.h>
 
 #if defined(CONFIG_EKF2_AIRSPEED)
@@ -357,6 +358,10 @@ private:
 
 	uORB::Subscription _airdata_sub{ORB_ID(vehicle_air_data)};
 
+# if defined(CONFIG_EKF2_BARO_COMPENSATION)
+	uORB::Subscription _vehicle_thrust_setpoint_sub {ORB_ID(vehicle_thrust_setpoint)};
+# endif // CONFIG_EKF2_BARO_COMPENSATION
+
 	uORB::PublicationMulti<estimator_bias_s> _estimator_baro_bias_pub{ORB_ID(estimator_baro_bias)};
 	uORB::PublicationMulti<estimator_aid_source1d_s> _estimator_aid_src_baro_hgt_pub {ORB_ID(estimator_aid_src_baro_hgt)};
 #endif // CONFIG_EKF2_BAROMETER
@@ -552,6 +557,7 @@ private:
 		(ParamExtFloat<px4::params::EKF2_PCOEF_YP>) _param_ekf2_pcoef_yp,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_YN>) _param_ekf2_pcoef_yn,
 		(ParamExtFloat<px4::params::EKF2_PCOEF_Z>) _param_ekf2_pcoef_z,
+		(ParamExtFloat<px4::params::EKF2_PCOEF_THR>) _param_ekf2_pcoef_thr,
 # endif // CONFIG_EKF2_BARO_COMPENSATION
 #endif // CONFIG_EKF2_BAROMETER
 

--- a/src/modules/ekf2/Kconfig
+++ b/src/modules/ekf2/Kconfig
@@ -57,7 +57,7 @@ depends on MODULES_EKF2
         bool "barometer compensation support"
         default y
 	depends on EKF2_BAROMETER
-	depends on EKF2_WIND
+	depends on EKF2_WIND # TODO: thrust-based compensation doesn't require wind; consider separate Kconfig symbol
 	---help---
 		EKF2 pressure compensation support.
 

--- a/src/modules/ekf2/Kconfig
+++ b/src/modules/ekf2/Kconfig
@@ -57,9 +57,9 @@ depends on MODULES_EKF2
         bool "barometer compensation support"
         default y
 	depends on EKF2_BAROMETER
-	depends on EKF2_WIND # TODO: thrust-based compensation doesn't require wind; consider separate Kconfig symbol
 	---help---
-		EKF2 pressure compensation support.
+		EKF2 barometer pressure compensation support (thrust and airspeed).
+		Airspeed-based compensation additionally requires EKF2_WIND.
 
 menuconfig EKF2_DRAG_FUSION
 depends on MODULES_EKF2

--- a/src/modules/ekf2/params_barometer.yaml
+++ b/src/modules/ekf2/params_barometer.yaml
@@ -136,6 +136,22 @@ parameters:
       max: 10.0
       unit: m
       decimal: 1
+    EKF2_PCOEF_TTAU:
+      description:
+        short: Thrust compensation time constant
+        long: First-order low-pass filter time constant applied to the thrust
+          signal before baro compensation. Models the delay between a thrust
+          setpoint change and the resulting pressure change at the baro sensor
+          (motor spin-up, propwash development, sensor response). Set to 0 to
+          disable filtering (instantaneous compensation). Typical values for
+          multirotors are 0.1 to 0.5 seconds. Use the baro_pressurization.py
+          calibration script to identify the optimal value from flight logs.
+      type: float
+      default: 0.0
+      min: 0.0
+      max: 2.0
+      unit: s
+      decimal: 2
     EKF2_ASPD_MAX:
       description:
         short: Maximum airspeed used for baro static pressure compensation

--- a/src/modules/ekf2/params_barometer.yaml
+++ b/src/modules/ekf2/params_barometer.yaml
@@ -119,6 +119,23 @@ parameters:
       min: -0.5
       max: 0.5
       decimal: 2
+    EKF2_PCOEF_THR:
+      description:
+        short: Baro altitude correction per unit normalized thrust
+        long: Baro altitude correction per unit of normalized collective thrust [0, 1].
+          Compensates for propwash-induced static pressure changes at the baro
+          sensor on multirotor vehicles. Positive values increase compensated
+          altitude (correct for baro reading too low under thrust). Negative values
+          decrease it (correct for baro reading too high under thrust). The required
+          sign depends on sensor placement relative to the rotors. Uses the thrust
+          setpoint as a proxy for actual thrust. Set to 0 to disable.
+          Not applied in fixed-wing mode.
+      type: float
+      default: 0.0
+      min: -10.0
+      max: 10.0
+      unit: m
+      decimal: 1
     EKF2_ASPD_MAX:
       description:
         short: Maximum airspeed used for baro static pressure compensation

--- a/src/modules/ekf2/params_barometer.yaml
+++ b/src/modules/ekf2/params_barometer.yaml
@@ -132,8 +132,8 @@ parameters:
           Not applied in fixed-wing mode.
       type: float
       default: 0.0
-      min: -10.0
-      max: 10.0
+      min: -30.0
+      max: 30.0
       unit: m
       decimal: 1
     EKF2_PCOEF_TTAU:
@@ -144,8 +144,9 @@ parameters:
           setpoint change and the resulting pressure change at the baro sensor
           (motor spin-up, propwash development, sensor response). Set to 0 to
           disable filtering (instantaneous compensation). Typical values for
-          multirotors are 0.1 to 0.5 seconds. Use the baro_pressurization.py
-          calibration script to identify the optimal value from flight logs.
+          multirotors are 0.1 to 0.5 seconds. Use the baro_thrust_calibration.py
+          script in Tools/baro_compensation to identify the optimal value from
+          flight logs.
       type: float
       default: 0.0
       min: 0.0

--- a/src/modules/ekf2/test/CMakeLists.txt
+++ b/src/modules/ekf2/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_subdirectory(test_helper)
 
 px4_add_unit_gtest(SRC test_EKF_accelerometer.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
 px4_add_unit_gtest(SRC test_EKF_airspeed.cpp LINKLIBS ecl_EKF ecl_sensor_sim ecl_test_helper)
+px4_add_unit_gtest(SRC test_EKF_baro_compensation.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
 px4_add_unit_gtest(SRC test_EKF_basics.cpp LINKLIBS ecl_EKF ecl_sensor_sim)
 px4_add_unit_gtest(SRC test_EKF_externalVision.cpp LINKLIBS ecl_EKF ecl_sensor_sim ecl_test_helper)
 px4_add_unit_gtest(SRC test_EKF_fake_pos.cpp LINKLIBS ecl_EKF ecl_sensor_sim ecl_test_helper)

--- a/src/modules/ekf2/test/sensor_simulator/baro.cpp
+++ b/src/modules/ekf2/test/sensor_simulator/baro.cpp
@@ -15,7 +15,7 @@ Baro::~Baro()
 
 void Baro::send(uint64_t time)
 {
-	_ekf->setBaroData(baroSample{time, _baro_data});
+	_ekf->setBaroData(baroSample{time, _baro_data, false, _thrust_magnitude});
 }
 
 void Baro::setData(float baro)

--- a/src/modules/ekf2/test/sensor_simulator/baro.h
+++ b/src/modules/ekf2/test/sensor_simulator/baro.h
@@ -54,8 +54,11 @@ public:
 	void setData(float baro);
 	float getData() const { return _baro_data; }
 
+	void setThrustMagnitude(float thrust) { _thrust_magnitude = thrust; }
+
 private:
 	float _baro_data{0.0f};
+	float _thrust_magnitude{0.0f};
 
 	void send(uint64_t time) override;
 

--- a/src/modules/ekf2/test/test_EKF_baro_compensation.cpp
+++ b/src/modules/ekf2/test/test_EKF_baro_compensation.cpp
@@ -134,3 +134,89 @@ TEST_F(EkfBaroCompensationTest, testThrustCompensationDisabledInFixedWing)
 	// Height should not change significantly — fixed-wing guard disables correction
 	EXPECT_NEAR(height_after, height_before, 0.1f);
 }
+
+TEST_F(EkfBaroCompensationTest, testThrustFilterSteadyState)
+{
+	// With a lag filter enabled, steady-state compensation should converge
+	// to the same value as without filtering
+	const float ekf2_pcoef_thr = 2.0f;
+	const float thrust_magnitude = 0.6f;
+
+	parameters *params = _ekf->getParamHandle();
+	params->ekf2_pcoef_thr = ekf2_pcoef_thr;
+	params->ekf2_pcoef_thr_tau = 0.2f;  // 200ms time constant
+
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+
+	_sensor_simulator._baro.setThrustMagnitude(thrust_magnitude);
+
+	// Run long enough for both the lag filter and EKF to converge
+	_sensor_simulator.runSeconds(30);
+
+	const float height_filtered = _ekf->getPosition()(2);
+
+	// Compare against a fresh instance with tau=0 (no filtering)
+	auto ekf_nofilter = std::make_shared<Ekf>();
+	SensorSimulator sim_nofilter(ekf_nofilter);
+	ekf_nofilter->init(0);
+	sim_nofilter.runSeconds(0.1);
+	ekf_nofilter->set_in_air_status(false);
+	ekf_nofilter->set_vehicle_at_rest(true);
+	sim_nofilter.runSeconds(7);
+
+	parameters *params_nf = ekf_nofilter->getParamHandle();
+	params_nf->ekf2_pcoef_thr = ekf2_pcoef_thr;
+	params_nf->ekf2_pcoef_thr_tau = 0.0f;
+
+	ekf_nofilter->set_in_air_status(true);
+	ekf_nofilter->set_vehicle_at_rest(false);
+	sim_nofilter._baro.setThrustMagnitude(thrust_magnitude);
+	sim_nofilter.runSeconds(30);
+
+	const float height_nofilter = ekf_nofilter->getPosition()(2);
+
+	// Steady-state should match within tolerance (EKF bias estimation noise)
+	EXPECT_NEAR(height_filtered, height_nofilter, 0.3f);
+}
+
+TEST_F(EkfBaroCompensationTest, testThrustFilterTransientDamping)
+{
+	// Verify that the lag filter damps the immediate response to a thrust step.
+	// After a thrust step, the filtered compensation at 1 second should be less
+	// than the steady-state value, demonstrating that the filter is smoothing.
+	const float ekf2_pcoef_thr = 2.0f;
+	const float tau = 0.3f;  // 300ms time constant
+
+	parameters *params = _ekf->getParamHandle();
+	params->ekf2_pcoef_thr = ekf2_pcoef_thr;
+	params->ekf2_pcoef_thr_tau = tau;
+
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+
+	// Start with zero thrust and let the filter settle
+	_sensor_simulator._baro.setThrustMagnitude(0.0f);
+	_sensor_simulator.runSeconds(5);
+
+	const float height_before_step = _ekf->getPosition()(2);
+
+	// Apply thrust step
+	_sensor_simulator._baro.setThrustMagnitude(0.8f);
+
+	// After a short time (~2*tau), the filtered thrust should still be ramping up,
+	// so the height change should be less than steady-state
+	_sensor_simulator.runSeconds(0.6);
+	const float height_short = _ekf->getPosition()(2);
+
+	// After a long time (>>tau), the filter converges
+	_sensor_simulator.runSeconds(29.4);
+	const float height_converged = _ekf->getPosition()(2);
+
+	// The short-term height change should be smaller than the converged change
+	// (filter is damping the transient)
+	const float delta_short = fabsf(height_short - height_before_step);
+	const float delta_converged = fabsf(height_converged - height_before_step);
+
+	EXPECT_LT(delta_short, delta_converged * 0.9f);
+}

--- a/src/modules/ekf2/test/test_EKF_baro_compensation.cpp
+++ b/src/modules/ekf2/test/test_EKF_baro_compensation.cpp
@@ -71,7 +71,7 @@ TEST_F(EkfBaroCompensationTest, testThrustCompensationDefault)
 	// With default parameter (0), thrust should have no effect on baro height
 	_ekf->set_in_air_status(true);
 	_ekf->set_vehicle_at_rest(false);
-	_ekf->set_thrust_magnitude(0.6f);
+	_sensor_simulator._baro.setThrustMagnitude(0.6f);
 
 	const float height_before = _ekf->getPosition()(2);
 
@@ -97,7 +97,7 @@ TEST_F(EkfBaroCompensationTest, testThrustCompensationPositive)
 
 	const float height_before = _ekf->getPosition()(2);
 
-	_ekf->set_thrust_magnitude(thrust_magnitude);
+	_sensor_simulator._baro.setThrustMagnitude(thrust_magnitude);
 	_sensor_simulator.runSeconds(20);
 
 	const float height_after = _ekf->getPosition()(2);
@@ -126,7 +126,7 @@ TEST_F(EkfBaroCompensationTest, testThrustCompensationDisabledInFixedWing)
 
 	const float height_before = _ekf->getPosition()(2);
 
-	_ekf->set_thrust_magnitude(0.6f);
+	_sensor_simulator._baro.setThrustMagnitude(0.6f);
 	_sensor_simulator.runSeconds(10);
 
 	const float height_after = _ekf->getPosition()(2);

--- a/src/modules/ekf2/test/test_EKF_baro_compensation.cpp
+++ b/src/modules/ekf2/test/test_EKF_baro_compensation.cpp
@@ -1,0 +1,136 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2026 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Test thrust-based baro propwash compensation (EKF2_PCOEF_THR)
+ */
+
+#include <gtest/gtest.h>
+#include "EKF/ekf.h"
+#include "sensor_simulator/sensor_simulator.h"
+#include "sensor_simulator/ekf_wrapper.h"
+
+class EkfBaroCompensationTest : public ::testing::Test
+{
+public:
+	EkfBaroCompensationTest(): ::testing::Test(),
+		_ekf{std::make_shared<Ekf>()},
+		_sensor_simulator(_ekf),
+		_ekf_wrapper(_ekf) {};
+
+	std::shared_ptr<Ekf> _ekf;
+	SensorSimulator _sensor_simulator;
+	EkfWrapper _ekf_wrapper;
+
+	void SetUp() override
+	{
+		_ekf->init(0);
+		_sensor_simulator.runSeconds(0.1);
+		_ekf->set_in_air_status(false);
+		_ekf->set_vehicle_at_rest(true);
+		_sensor_simulator.runSeconds(7);
+	}
+
+	void TearDown() override
+	{
+	}
+};
+
+TEST_F(EkfBaroCompensationTest, testThrustCompensationDefault)
+{
+	// With default parameter (0), thrust should have no effect on baro height
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+	_ekf->set_thrust_magnitude(0.6f);
+
+	const float height_before = _ekf->getPosition()(2);
+
+	_sensor_simulator.runSeconds(10);
+
+	const float height_after = _ekf->getPosition()(2);
+
+	// Height should not change significantly (only normal drift)
+	EXPECT_NEAR(height_after, height_before, 0.1f);
+}
+
+TEST_F(EkfBaroCompensationTest, testThrustCompensationPositive)
+{
+	// Set a positive correction coefficient and apply thrust
+	const float ekf2_pcoef_thr = 2.0f;
+	const float thrust_magnitude = 0.6f;
+
+	parameters *params = _ekf->getParamHandle();
+	params->ekf2_pcoef_thr = ekf2_pcoef_thr;
+
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+
+	const float height_before = _ekf->getPosition()(2);
+
+	_ekf->set_thrust_magnitude(thrust_magnitude);
+	_sensor_simulator.runSeconds(20);
+
+	const float height_after = _ekf->getPosition()(2);
+
+	// Positive pcoef_thr increases baro_alt, which means the EKF sees a higher
+	// baro measurement. The EKF state z (NED down) should decrease (altitude increases).
+	// Instantaneous baro altitude offset: ekf2_pcoef_thr * thrust_magnitude = 1.2 m
+	const float expected_correction = ekf2_pcoef_thr * thrust_magnitude;
+
+	// The EKF fuses this over time; check that height moved in the expected direction
+	// and the magnitude is in the right ballpark
+	EXPECT_LT(height_after, height_before - 0.5f * expected_correction);
+}
+
+TEST_F(EkfBaroCompensationTest, testThrustCompensationDisabledInFixedWing)
+{
+	// Thrust compensation should not apply in fixed-wing mode
+	const float ekf2_pcoef_thr = 2.0f;
+
+	parameters *params = _ekf->getParamHandle();
+	params->ekf2_pcoef_thr = ekf2_pcoef_thr;
+
+	_ekf->set_in_air_status(true);
+	_ekf->set_vehicle_at_rest(false);
+	_ekf->set_is_fixed_wing(true);
+
+	const float height_before = _ekf->getPosition()(2);
+
+	_ekf->set_thrust_magnitude(0.6f);
+	_sensor_simulator.runSeconds(10);
+
+	const float height_after = _ekf->getPosition()(2);
+
+	// Height should not change significantly — fixed-wing guard disables correction
+	EXPECT_NEAR(height_after, height_before, 0.1f);
+}

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -377,6 +377,8 @@ void LoggedTopics::add_high_rate_sensors_topics()
 	add_topic_multi("sensor_gps", 0, 4);
 	add_topic_multi("sensor_gnss_relative", 0, 1);
 	add_topic_multi("sensor_mag", 0, 4);
+	add_topic("vehicle_air_data");
+	add_topic("estimator_aid_src_baro_hgt");
 }
 
 void LoggedTopics::add_mavlink_tunnel()


### PR DESCRIPTION
## Summary

Add thrust-based barometric pressure compensation for multirotors with a first-order lag filter to model the physical delay between thrust changes and baro pressure response.

### Problem

Propwash from rotors causes static pressure errors at the baro sensor proportional to thrust. A naive instantaneous correction (baro += K * thrust) over-corrects during transients because the thrust setpoint leads the actual pressure effect by 80-350ms (motor spin-up, propwash development, sensor response).

### Solution

Two new parameters:

| Parameter | Description | Default |
|---|---|---|
| EKF2_PCOEF_THR | Gain: baro altitude correction per unit normalized thrust (m) | 0.0 |
| EKF2_PCOEF_TTAU | Time constant: first-order lag filter on thrust before compensation (s) | 0.0 |

The compensation model: baro_alt += EKF2_PCOEF_THR * LPF(thrust, EKF2_PCOEF_TTAU)

With EKF2_PCOEF_TTAU > 0, thrust passes through an AlphaFilter (alpha = dt / (dt + tau)) before being used for compensation. This models the gradual development of propwash pressure after a thrust change, preventing transient over/under-correction.

With EKF2_PCOEF_TTAU = 0, the filter is bypassed and behavior is identical to pure instantaneous compensation.

### Calibration

A companion calibration script (baro_pressurization.py --calibrate) performs system identification from flight logs:
1. Cross-correlates thrust vs baro residual (baro - range sensor) to find delay structure
2. Grid-searches time constants, fitting gain K for each via least-squares
3. Selects the tau that maximizes R-squared
4. Outputs recommended EKF2_PCOEF_THR and EKF2_PCOEF_TTAU values

### Design

This is distinct from the existing PCOEF_{X,Y,Z} airspeed-based compensation:

| Parameter | What it corrects | Scales with | Requires |
|---|---|---|---|
| EKF2_PCOEF_{X,Y,Z} | Airspeed-induced pressure errors (Bernoulli) | 0.5 * rho * V_air^2 | Wind estimate |
| EKF2_PCOEF_THR | Propwash-induced pressure errors | Normalized thrust [0, 1] | Nothing extra |

Not applied in fixed-wing mode. Both parameters default to 0 (disabled, backward compatible).

## Test plan

- [ ] SITL: verify default parameters (0) produce identical behavior to baseline
- [ ] SITL: verify non-zero EKF2_PCOEF_THR with EKF2_PCOEF_TTAU = 0 applies instantaneous correction
- [ ] SITL: verify non-zero EKF2_PCOEF_TTAU damps transient response to thrust steps
- [ ] Flight test: calibrate with baro_pressurization.py --calibrate, set recommended params, compare baro height error
- [ ] Verify fixed-wing guard: correction must not apply when fixed_wing flag is set
- [ ] Unit tests pass (test_EKF_baro_compensation - 5 tests including steady-state convergence and transient damping)