### PR TITLE
fix(ekf2): replace baro ground effect deadzone with variance inflation

### DIFF
--- a/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
+++ b/src/modules/ekf2/EKF/aid_sources/barometer/baro_height_control.cpp
@@ -57,7 +57,12 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 		const float measurement = baro_sample.hgt;
 #endif
 
-		const float measurement_var = sq(_params.ekf2_baro_noise);
+		float measurement_var = sq(_params.ekf2_baro_noise);
+
+		// Inflate baro noise during ground effect to reduce its influence on the height estimate
+		if (_control_status.flags.gnd_effect && (_params.ekf2_baro_ge_ni > 0.f)) {
+			measurement_var += sq(_params.ekf2_baro_ge_ni);
+		}
 
 		const bool measurement_valid = PX4_ISFINITE(measurement) && PX4_ISFINITE(measurement_var);
 
@@ -84,23 +89,6 @@ void Ekf::controlBaroHeightFusion(const imuSample &imu_sample)
 						-(measurement - bias_est.getBias()),      // observation
 						measurement_var + bias_est.getBiasVar(),  // observation variance
 						math::max(_params.ekf2_baro_gate, 1.f)); // innovation gate
-
-		// Compensate for positive static pressure transients (negative vertical position innovations)
-		// caused by rotor wash ground interaction by applying a temporary deadzone to baro innovations.
-		if (_control_status.flags.gnd_effect && (_params.ekf2_gnd_eff_dz > 0.f)) {
-
-			const float deadzone_start = 0.0f;
-			const float deadzone_end = deadzone_start + _params.ekf2_gnd_eff_dz;
-
-			if (aid_src.innovation < -deadzone_start) {
-				if (aid_src.innovation <= -deadzone_end) {
-					aid_src.innovation += deadzone_end;
-
-				} else {
-					aid_src.innovation = -deadzone_start;
-				}
-			}
-		}
 
 		// update the bias estimator before updating the main filter but after
 		// using its current state to compute the vertical position innovation

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -312,8 +312,8 @@ struct parameters {
 	float baro_bias_nsd{0.13f};             ///< process noise for barometric height bias estimation (m/s/sqrt(Hz))
 	float ekf2_baro_gate{5.0f};             ///< barometric and GPS height innovation consistency gate size (STD)
 
-	float ekf2_gnd_eff_dz{5.0f};            ///< Size of deadzone applied to negative baro innovations when ground effect compensation is active (m)
-	float ekf2_gnd_max_hgt{0.5f};           ///< Height above ground at which baro ground effect becomes insignificant (m)
+	float ekf2_baro_ge_ni{4.0f};            ///< Baro noise inflation during ground effect (m)
+	float ekf2_baro_ge_hgt{0.25f};          ///< Height above ground below which ground effect is active (m)
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
 	// static barometer pressure position error coefficient along body axes

--- a/src/modules/ekf2/EKF/common.h
+++ b/src/modules/ekf2/EKF/common.h
@@ -83,9 +83,7 @@ static constexpr uint64_t BADACC_PROBATION =
 static constexpr float BADACC_BIAS_PNOISE =
 	4.9f;  ///< The delta velocity process noise is set to this when accel data is declared bad (m/sec**2)
 
-// ground effect compensation
-static constexpr uint64_t GNDEFFECT_TIMEOUT =
-	10e6; ///< Maximum period of time that ground effect protection will be active after it was last turned on (uSec)
+
 
 enum class PositionFrame : uint8_t {
 	LOCAL_FRAME_NED = 0,

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -61,7 +61,8 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 			set_in_transition(system_flags_delayed.in_transition);
 
 			if (system_flags_delayed.gnd_effect) {
-				set_gnd_effect();
+				_control_status.flags.gnd_effect = true;
+				_time_last_gnd_effect_on = _time_delayed_us;
 			}
 
 			set_constant_pos(system_flags_delayed.constant_pos);

--- a/src/modules/ekf2/EKF/control.cpp
+++ b/src/modules/ekf2/EKF/control.cpp
@@ -62,7 +62,6 @@ void Ekf::controlFusionModes(const imuSample &imu_delayed)
 
 			if (system_flags_delayed.gnd_effect) {
 				_control_status.flags.gnd_effect = true;
-				_time_last_gnd_effect_on = _time_delayed_us;
 			}
 
 			set_constant_pos(system_flags_delayed.constant_pos);

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -945,21 +945,33 @@ float Ekf::getTiltVariance() const
 void Ekf::updateGroundEffect()
 {
 	if (_control_status.flags.in_air && !_control_status.flags.fixed_wing) {
+		bool gnd_effect = false;
+
 #if defined(CONFIG_EKF2_TERRAIN)
 
 		if (isTerrainEstimateValid()) {
-			// automatically set ground effect if terrain is valid
-			float height = getHagl();
-			_control_status.flags.gnd_effect = (height < _params.ekf2_gnd_max_hgt);
+			gnd_effect = (getHagl() < _params.ekf2_baro_ge_hgt);
 
 		} else
 #endif // CONFIG_EKF2_TERRAIN
-			if (_control_status.flags.gnd_effect) {
-				// Turn off ground effect compensation if it times out
-				if (isTimedOut(_time_last_gnd_effect_on, GNDEFFECT_TIMEOUT)) {
-					_control_status.flags.gnd_effect = false;
-				}
+#if defined(CONFIG_EKF2_RANGE_FINDER)
+
+			if (_range_sensor.isDataHealthy()) {
+				gnd_effect = (_range_sensor.getDistBottom() < _params.ekf2_baro_ge_hgt);
+
+			} else
+#endif // CONFIG_EKF2_RANGE_FINDER
+			{
+				// No height-above-ground source available — hold current state until timeout
+				gnd_effect = _control_status.flags.gnd_effect
+					     && !isTimedOut(_time_last_gnd_effect_on, GNDEFFECT_TIMEOUT);
 			}
+
+		if (gnd_effect) {
+			_time_last_gnd_effect_on = _time_delayed_us;
+		}
+
+		_control_status.flags.gnd_effect = gnd_effect;
 
 	} else {
 		_control_status.flags.gnd_effect = false;

--- a/src/modules/ekf2/EKF/ekf_helper.cpp
+++ b/src/modules/ekf2/EKF/ekf_helper.cpp
@@ -944,8 +944,14 @@ float Ekf::getTiltVariance() const
 #if defined(CONFIG_EKF2_BAROMETER)
 void Ekf::updateGroundEffect()
 {
-	if (_control_status.flags.in_air && !_control_status.flags.fixed_wing) {
+	if (!_control_status.flags.fixed_wing) {
 		bool gnd_effect = false;
+
+		if (!_control_status.flags.in_air) {
+			// On the ground — always in ground effect zone
+			_control_status.flags.gnd_effect = true;
+			return;
+		}
 
 #if defined(CONFIG_EKF2_TERRAIN)
 
@@ -962,14 +968,9 @@ void Ekf::updateGroundEffect()
 			} else
 #endif // CONFIG_EKF2_RANGE_FINDER
 			{
-				// No height-above-ground source available — hold current state until timeout
-				gnd_effect = _control_status.flags.gnd_effect
-					     && !isTimedOut(_time_last_gnd_effect_on, GNDEFFECT_TIMEOUT);
+				// No terrain or range source — use EKF height above origin as proxy
+				gnd_effect = (-_state.pos(2) < _params.ekf2_baro_ge_hgt);
 			}
-
-		if (gnd_effect) {
-			_time_last_gnd_effect_on = _time_delayed_us;
-		}
 
 		_control_status.flags.gnd_effect = gnd_effect;
 

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -451,8 +451,6 @@ protected:
 	uint64_t _time_last_baro_buffer_push{0};
 #endif // CONFIG_EKF2_BAROMETER
 
-	uint64_t _time_last_gnd_effect_on{0};
-
 	fault_status_u _fault_status{};
 
 	// allocate data buffers and initialize interface variables

--- a/src/modules/ekf2/EKF/estimator_interface.h
+++ b/src/modules/ekf2/EKF/estimator_interface.h
@@ -199,14 +199,6 @@ public:
 
 	void set_in_transition(bool in_transition) { _control_status.flags.in_transition = in_transition; }
 
-	// set flag if static pressure rise due to ground effect is expected
-	// use _params.ekf2_gnd_eff_dz to adjust for expected rise in static pressure
-	// flag will clear after GNDEFFECT_TIMEOUT uSec
-	void set_gnd_effect()
-	{
-		_control_status.flags.gnd_effect = true;
-		_time_last_gnd_effect_on = _time_delayed_us;
-	}
 
 	// set air density used by the multi-rotor specific drag force fusion
 	void set_air_density(float air_density) { _air_density = air_density; }

--- a/src/modules/ekf2/EKF2.cpp
+++ b/src/modules/ekf2/EKF2.cpp
@@ -100,8 +100,8 @@ EKF2::EKF2(bool multi_mode, const px4::wq_config_t &config, bool replay_mode):
 	_param_ekf2_baro_delay(_params->ekf2_baro_delay),
 	_param_ekf2_baro_noise(_params->ekf2_baro_noise),
 	_param_ekf2_baro_gate(_params->ekf2_baro_gate),
-	_param_ekf2_gnd_eff_dz(_params->ekf2_gnd_eff_dz),
-	_param_ekf2_gnd_max_hgt(_params->ekf2_gnd_max_hgt),
+	_param_ekf2_baro_ge_ni(_params->ekf2_baro_ge_ni),
+	_param_ekf2_baro_ge_hgt(_params->ekf2_baro_ge_hgt),
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
 	_param_ekf2_aspd_max(_params->ekf2_aspd_max),
 	_param_ekf2_pcoef_xp(_params->ekf2_pcoef_xp),

--- a/src/modules/ekf2/EKF2.hpp
+++ b/src/modules/ekf2/EKF2.hpp
@@ -541,8 +541,8 @@ private:
 		(ParamExtFloat<px4::params::EKF2_BARO_DELAY>) _param_ekf2_baro_delay,
 		(ParamExtFloat<px4::params::EKF2_BARO_NOISE>) _param_ekf2_baro_noise,
 		(ParamExtFloat<px4::params::EKF2_BARO_GATE>) _param_ekf2_baro_gate,
-		(ParamExtFloat<px4::params::EKF2_GND_EFF_DZ>) _param_ekf2_gnd_eff_dz,
-		(ParamExtFloat<px4::params::EKF2_GND_MAX_HGT>) _param_ekf2_gnd_max_hgt,
+		(ParamExtFloat<px4::params::EKF2_BARO_GE_NI>) _param_ekf2_baro_ge_ni,
+		(ParamExtFloat<px4::params::EKF2_BARO_GE_HGT>) _param_ekf2_baro_ge_hgt,
 
 # if defined(CONFIG_EKF2_BARO_COMPENSATION)
 		// Corrections for static pressure position error where Ps_error = Ps_meas - Ps_truth

--- a/src/modules/ekf2/params_barometer.yaml
+++ b/src/modules/ekf2/params_barometer.yaml
@@ -39,26 +39,27 @@ parameters:
       max: 15.0
       unit: m
       decimal: 2
-    EKF2_GND_EFF_DZ:
+    EKF2_BARO_GE_NI:
       description:
-        short: Baro deadzone range for height fusion
-        long: Sets the value of deadzone applied to negative baro innovations. Deadzone
-          is enabled when EKF2_GND_EFF_DZ > 0.
+        short: Baro noise inflation during ground effect
+        long: Increases baro measurement noise when ground effect is detected, reducing
+          its influence on the height estimate. Set to 0 to disable ground effect
+          compensation.
       type: float
       default: 4.0
       min: 0.0
-      max: 10.0
+      max: 40.0
       unit: m
       decimal: 1
-    EKF2_GND_MAX_HGT:
+    EKF2_BARO_GE_HGT:
       description:
         short: Height above ground level for ground effect zone
-        long: Sets the maximum distance to the ground level where negative baro innovations
-          are expected.
+        long: Sets the maximum height above ground at which ground effect compensation
+          is active.
       type: float
-      default: 0.5
+      default: 0.25
       min: 0.0
-      max: 5.0
+      max: 10.0
       unit: m
       decimal: 1
     EKF2_PCOEF_XP:

--- a/src/modules/ekf2/test/test_EKF_height_fusion.cpp
+++ b/src/modules/ekf2/test/test_EKF_height_fusion.cpp
@@ -59,6 +59,7 @@ public:
 	void SetUp() override
 	{
 		_ekf->init(0);
+		_ekf->getParamHandle()->ekf2_baro_ge_ni = 0.f; // disable ground effect for base tests
 		_ekf_wrapper.disableBaroHeightFusion();
 		_ekf_wrapper.disableRangeHeightFusion();
 		_sensor_simulator.runSeconds(0.1);
@@ -414,4 +415,64 @@ TEST_F(EkfHeightFusionTest, changeEkfOriginAlt)
 
 	EXPECT_TRUE(reset_logging_checker.isVerticalVelocityResetCounterIncreasedBy(0));
 	EXPECT_TRUE(reset_logging_checker.isVerticalPositionResetCounterIncreasedBy(1));
+}
+
+TEST_F(EkfHeightFusionTest, baroGroundEffectVarianceInflation)
+{
+	// GIVEN: GPS reference with baro and range fusion, ground effect enabled
+	const float ge_ni = 4.0f;
+	const float ge_hgt = 1.0f;
+	_ekf->getParamHandle()->ekf2_baro_ge_ni = ge_ni;
+	_ekf->getParamHandle()->ekf2_baro_ge_hgt = ge_hgt;
+
+	_ekf_wrapper.setGpsHeightRef();
+	_ekf_wrapper.enableBaroHeightFusion();
+	_ekf_wrapper.enableGpsHeightFusion();
+	_ekf_wrapper.enableRangeHeightFusion();
+
+	// Range reports low altitude -> ground effect should activate
+	_sensor_simulator._rng.setData(0.5f, 100);
+	_sensor_simulator.runSeconds(11);
+
+	EXPECT_TRUE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	EXPECT_TRUE(_ekf->control_status_flags().gnd_effect);
+
+	const float baro_noise = _ekf->getParamHandle()->ekf2_baro_noise;
+	const float nominal_var = baro_noise * baro_noise;
+	const float expected_inflation = ge_ni * ge_ni;
+
+	// observation_variance includes bias var, so check that it exceeds nominal + inflation
+	EXPECT_GT(_ekf->aid_src_baro_hgt().observation_variance, nominal_var + expected_inflation * 0.9f);
+
+	// WHEN: range reports high altitude -> ground effect should clear after terrain converges
+	_sensor_simulator._rng.setData(5.0f, 100);
+	_sensor_simulator.runSeconds(15);
+
+	EXPECT_FALSE(_ekf->control_status_flags().gnd_effect);
+	EXPECT_LT(_ekf->aid_src_baro_hgt().observation_variance, nominal_var + expected_inflation);
+}
+
+TEST_F(EkfHeightFusionTest, baroGroundEffectDisabledWhenParamZero)
+{
+	// GIVEN: GPS reference with baro and range, ground effect noise inflation param set to zero
+	_ekf->getParamHandle()->ekf2_baro_ge_ni = 0.f;
+	_ekf->getParamHandle()->ekf2_baro_ge_hgt = 1.0f;
+
+	_ekf_wrapper.setGpsHeightRef();
+	_ekf_wrapper.enableBaroHeightFusion();
+	_ekf_wrapper.enableGpsHeightFusion();
+	_ekf_wrapper.enableRangeHeightFusion();
+
+	// Range reports low altitude — ground effect flag is set but variance is not inflated
+	_sensor_simulator._rng.setData(0.5f, 100);
+	_sensor_simulator.runSeconds(11);
+
+	EXPECT_TRUE(_ekf_wrapper.isIntendingBaroHeightFusion());
+	EXPECT_TRUE(_ekf->control_status_flags().gnd_effect);
+
+	const float baro_noise = _ekf->getParamHandle()->ekf2_baro_noise;
+	const float nominal_var = baro_noise * baro_noise;
+
+	// observation_variance should be near nominal (plus bias var) with no GE inflation
+	EXPECT_LT(_ekf->aid_src_baro_hgt().observation_variance, nominal_var * 3.f);
 }


### PR DESCRIPTION
## Summary
- Replace one-sided baro innovation deadzone with symmetric observation variance inflation during ground effect — makes innovation variance, test ratio, Kalman gain, and bias estimator all consistent
- Improve ground effect detection with fallback chain: terrain estimate → raw range sensor → land detector timeout
- Rename params: `EKF2_GND_EFF_DZ` → `EKF2_BARO_GE_NI`, `EKF2_GND_MAX_HGT` → `EKF2_BARO_GE_HGT`

Supersedes #31.

## Test plan
- [x] EKF2 height fusion unit tests pass (11/11)
- [x] `baroGroundEffectVarianceInflation`: verifies GE activates at low altitude and baro variance is inflated, then clears at high altitude
- [x] `baroGroundEffectDisabledWhenParamZero`: verifies no inflation when `EKF2_BARO_GE_NI=0`
- [ ] Flight test with compensated baro data to verify height estimate quality during takeoff/landing