### PR TITLE
optical_flow: log mode transitions in PAW3902 and PAA3905

### DIFF
--- a/src/drivers/optical_flow/paa3905/PAA3905.cpp
+++ b/src/drivers/optical_flow/paa3905/PAA3905.cpp
@@ -306,6 +306,9 @@ void PAA3905::RunImpl()
 					}
 
 					if (prev_mode != _mode) {
+						static constexpr const char *mode_str[] = {"Bright", "LowLight", "SuperLowLight"};
+						PX4_INFO("mode: %s -> %s", mode_str[static_cast<int>(prev_mode)], mode_str[static_cast<int>(_mode)]);
+
 						// update scheduling on mode change
 						if (!_motion_interrupt_enabled) {
 							ScheduleOnInterval(_scheduled_interval_us, _scheduled_interval_us);

--- a/src/drivers/optical_flow/paw3902/PAW3902.cpp
+++ b/src/drivers/optical_flow/paw3902/PAW3902.cpp
@@ -313,6 +313,7 @@ void PAW3902::RunImpl()
 						_bright_to_low_counter++;
 
 						if (_bright_to_low_counter >= 10) {
+							PX4_INFO("mode: Bright -> LowLight");
 							_mode = Mode::LowLight;
 							Reset();
 						}
@@ -341,6 +342,7 @@ void PAW3902::RunImpl()
 						_low_to_superlow_counter++;
 
 						if (_low_to_superlow_counter >= 10) {
+							PX4_INFO("mode: LowLight -> SuperLowLight");
 							_mode = Mode::SuperLowLight;
 							Reset();
 						}
@@ -352,6 +354,7 @@ void PAW3902::RunImpl()
 						_low_to_superlow_counter = 0;
 
 						if (_low_to_bright_counter >= 10) {
+							PX4_INFO("mode: LowLight -> Bright");
 							_mode = Mode::Bright;
 							Reset();
 						}
@@ -387,6 +390,7 @@ void PAW3902::RunImpl()
 					}
 
 					if (_superlow_to_low_counter >= 10) {
+						PX4_INFO("mode: SuperLowLight -> LowLight");
 						_mode = Mode::LowLight;
 						Reset();
 					}


### PR DESCRIPTION
## Summary
- Add `PX4_INFO` messages when PAW3902 and PAA3905 sensors switch between Bright, LowLight, and SuperLowLight modes
- Makes mode transitions visible in flight logs for diagnosing flow data gaps during lighting changes
- Particularly important for CAN nodes (ARK Flow) where the `sensor_optical_flow.mode` field may not be readily observable

## Context
Mode transitions in PAW3902 cause a sensor reset (~1s data gap). Combined with the EKF2 flow re-engagement timeout, a lighting change can mean ~3s of dead-reckoning. Having these transitions in the logs is a first step toward diagnosing and mitigating the issue.

## Test plan
- [ ] Build for `px4_fmu-v6x_default`
- [ ] Verify log output on PAW3902 mode change (e.g. cover/uncover sensor to trigger bright↔lowlight)
- [ ] Verify log output on PAA3905 mode change

🤖 Generated with [Claude Code](https://claude.com/claude-code)