### PR TITLE
feat(sensors): barometer thrust compensation with online estimator

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_apps
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_apps
@@ -29,6 +29,13 @@ fi
 # Start Multicopter Position Controller.
 #
 mc_hover_thrust_estimator start
+
+# Bit 1 of SENS_BAR_AUTOCAL enables online thrust compensation (value > 1)
+if param greater -s SENS_BAR_AUTOCAL 1
+then
+	baro_thrust_estimator start
+fi
+
 flight_mode_manager start
 mc_pos_control start
 

--- a/Tools/baro_compensation/README.md
+++ b/Tools/baro_compensation/README.md
@@ -1,0 +1,150 @@
+# Barometer Thrust Compensation Analysis
+
+Post-flight analysis tool for barometer thrust compensation. Works with the
+online `baro_thrust_estimator` module and/or a range sensor for ground truth.
+
+## Background
+
+Propwash from propellers changes the static pressure at the barometer sensor.
+This creates a thrust-dependent altitude error: as thrust increases, the baro
+reading shifts. The direction and magnitude depend on sensor placement relative
+to the propellers.
+
+The `vehicle_air_data` module compensates for this by applying a correction to
+the barometer altitude before publishing:
+
+```
+corrected_baro_alt = raw_baro_alt + SENS_BARO_PCOEF * abs(thrust_z)
+```
+
+where `thrust_z` is the Z body-axis component of `vehicle_thrust_setpoint`
+[0, 1]. Using the vertical thrust setpoint (rather than individual motor
+outputs) provides correct behavior for both multicopter and VTOL aircraft.
+
+## How Calibration Works
+
+### Online (Preferred)
+
+The online estimator is enabled by default (`SENS_BAR_AUTOCAL` bit 1).
+The `baro_thrust_estimator` module identifies `SENS_BARO_PCOEF` automatically
+during flight using an accel-baro complementary filter and RLS estimation.
+Parameters are saved to flash on disarm once converged, and the estimator
+continues to refine PCOEF over subsequent flights. No range sensor required.
+
+### Offline (This Tool)
+
+This tool identifies PCOEF from a flight log using a range sensor as ground
+truth. Useful for:
+- Validating online estimator results against ground truth
+- Analyzing compensation effectiveness
+- Initial calibration when the online estimator hasn't converged yet
+
+## Prerequisites
+
+- **Python packages**: `pyulog`, `numpy`, `matplotlib`
+
+  ```bash
+  pip install pyulog numpy matplotlib
+  ```
+
+## Analysis Modes
+
+The tool automatically selects a mode based on what data is in the log:
+
+### 1. Estimator Review (online estimator logged, no range sensor)
+
+Shows what the online estimator did during the flight:
+- K estimate convergence with uncertainty band
+- Prediction error and thrust excitation
+- Convergence status timeline
+- Compensation effect (residual before/after correction)
+
+### 2. Full Validation (online estimator + range sensor)
+
+Cross-validates the online estimator against range-sensor ground truth:
+- All estimator review plots (above)
+- Side-by-side comparison of online vs offline compensation
+- Scatter plots comparing raw, online-corrected, and offline-corrected error
+
+### 3. Standalone Calibration (range sensor, no estimator)
+
+Identifies PCOEF from baro vs range error:
+- Cross-correlation delay analysis
+- Recommended PCOEF value
+
+## Usage
+
+```bash
+python3 baro_thrust_calibration.py <path/to/log.ulg> [--output-dir <dir>]
+```
+
+## Output
+
+### Console
+
+Summary including parameters found in the log, online estimator convergence
+status, range-based error statistics, and cross-validation between online and
+offline identification (when both are available).
+
+### PDF Report (`baro_calibration.pdf`)
+
+Pages vary by mode. When the online estimator is present:
+
+**Altitude Overview** — Baro observation, EKF altitude, distance sensor (if
+available), and thrust over time.
+
+**Estimator Convergence** — K estimate with variance band, error variance
+and thrust excitation, convergence flags over time.
+
+**Compensation Effect** — CF residual before/after applying estimated K,
+scatter plots, and compensation statistics.
+
+When a range sensor is present, additional pages show:
+
+**Compensation Comparison** — Side-by-side baro/range altitude with online
+vs offline correction applied.
+
+**Online vs Offline Scatter** — Error vs thrust scatter for raw, online-
+corrected, and offline-corrected data.
+
+## Manual Calibration Procedure
+
+If not using the online estimator, you can calibrate manually:
+
+1. **Disable existing compensation**:
+   ```
+   param set SENS_BARO_PCOEF 0.0
+   ```
+
+2. **Fly a hover** at 2-5 m AGL for at least 60 seconds with some gentle
+   altitude changes. A range sensor must be installed.
+
+3. **Run this tool** on the log and apply the recommended parameter:
+   ```
+   param set SENS_BARO_PCOEF <value>
+   ```
+
+4. **Fly again** and re-run the tool to verify (it will auto-detect validation
+   mode when compensation parameters are active).
+
+## Interpreting Results
+
+| Metric | Good | Marginal | Poor |
+|--------|------|----------|------|
+| Thrust correlation abs(r) | > 0.6 | 0.3 - 0.6 | < 0.3 |
+| Model R^2 | > 0.3 | 0.1 - 0.3 | < 0.1 |
+| Compensated abs(r) | < 0.2 | 0.2 - 0.4 | > 0.4 |
+
+- **Low R^2**: Thrust is not the dominant baro error source. Consider thermal
+  drift, ground effect, or sensor placement issues.
+- **Very large K (> 5 m)**: May indicate a sensor mounting issue. The baro
+  should be shielded from direct propwash where possible.
+- **Online/offline K disagreement > 2 m**: The estimator may not have had
+  enough excitation. Fly longer or with more altitude variation.
+
+## Parameters Reference
+
+| Parameter | Description | Range | Default |
+|-----------|-------------|-------|---------|
+| `SENS_BARO_PCOEF` | Baro altitude correction per unit vertical thrust [m] | -30 to 30 | 0.0 |
+| `SENS_BAR_AUTOCAL` | Bitmask: bit 0 = GNSS offset, bit 1 = online thrust cal | 0 to 3 | 1 |

--- a/Tools/baro_compensation/README.md
+++ b/Tools/baro_compensation/README.md
@@ -89,7 +89,7 @@ Summary including parameters found in the log, online estimator convergence
 status, range-based error statistics, and cross-validation between online and
 offline identification (when both are available).
 
-### PDF Report (`baro_calibration.pdf`)
+### PDF Report (`<log_name>.pdf`)
 
 Pages vary by mode. When the online estimator is present:
 

--- a/Tools/baro_compensation/README.md
+++ b/Tools/baro_compensation/README.md
@@ -17,15 +17,18 @@ the barometer altitude before publishing:
 corrected_baro_alt = raw_baro_alt + SENS_BARO_PCOEF * abs(thrust_z)
 ```
 
-where `thrust_z` is the Z body-axis component of `vehicle_thrust_setpoint`
-[0, 1]. Using the vertical thrust setpoint (rather than individual motor
-outputs) provides correct behavior for both multicopter and VTOL aircraft.
+where `thrust_z` is the Z body-axis component (`vehicle_thrust_setpoint.xyz[2]`),
+which is signed in PX4 (negative for upward thrust in FRD). The correction uses
+its magnitude `|thrust_z|` in [0, 1]. Using the vertical thrust setpoint (rather
+than individual motor outputs) provides correct behavior for both multicopter and
+VTOL aircraft.
 
 ## How Calibration Works
 
 ### Online (Preferred)
 
-The online estimator is enabled by default (`SENS_BAR_AUTOCAL` bit 1).
+The online estimator is disabled by default. Enable it by setting
+`SENS_BAR_AUTOCAL` bit 1 (e.g. set to 3 for both GNSS cal and thrust comp).
 The `baro_thrust_estimator` module identifies `SENS_BARO_PCOEF` automatically
 during flight using an accel-baro complementary filter and RLS estimation.
 Parameters are saved to flash on disarm once converged, and the estimator

--- a/Tools/baro_compensation/baro_thrust_calibration.py
+++ b/Tools/baro_compensation/baro_thrust_calibration.py
@@ -20,10 +20,11 @@ Requirements:
     - Python packages: pyulog, numpy, matplotlib
 
 Usage:
-    python3 baro_thrust_calibration.py <log.ulg> [--output-dir <dir>]  (default: /tmp/baro_analysis)
+    python3 baro_thrust_calibration.py <log.ulg> [--output-dir <dir>]
+        If --output-dir is not given, results are written to logs/<log_name>/ in the PX4 root.
 
 Outputs:
-    - baro_calibration.pdf    Analysis plots
+    - <log_name>.pdf    Analysis plots (saved in the output directory)
     - Console output with parameters and diagnostics
 """
 
@@ -611,11 +612,11 @@ def plot_residual_diagnostics(diag, calib):
         "  Model R\u00b2 comparison:",
         f"    Linear (zero lag):     {diag['linear_r2']:.3f}",
         f"    Linear (best lag):     {diag['best_lag_r2']:.3f}"
-        f"  (+{r2_gain_lag:.3f})",
+        f"  (+{r2_gain_lag:.3f})",  # noqa: intentional string concat
         f"    Quadratic (zero lag):  {diag['quad_r2']:.3f}"
-        f"  (+{r2_gain_quad:.3f})",
+        f"  (+{r2_gain_quad:.3f})",  # noqa: intentional string concat
         f"    Quadratic + best lag:  {diag['combined_r2']:.3f}"
-        f"  (+{r2_gain_comb:.3f})",
+        f"  (+{r2_gain_comb:.3f})",  # noqa: intentional string concat
         "",
         f"  Optimal lag: {diag['best_lag_s']*1000:+.0f}ms",
         "",

--- a/Tools/baro_compensation/baro_thrust_calibration.py
+++ b/Tools/baro_compensation/baro_thrust_calibration.py
@@ -13,7 +13,7 @@ Analyzes baro thrust compensation from flight logs. Three modes:
 3. **Standalone calibration** (range sensor, no estimator):
    Identifies SENS_BARO_PCOEF from baro vs range error.
 
-The correction model: baro_alt += SENS_BARO_PCOEF * mean_motor_output
+The correction model: baro_alt += SENS_BARO_PCOEF * |thrust_z|
 
 Requirements:
     - Flight log (.ulg)
@@ -82,27 +82,16 @@ def us_to_seconds(ts_us, start_us):
     return (ts_us.astype(np.int64) - np.int64(start_us)) / 1e6
 
 
-def mean_motor_thrust(motors_data):
-    """Compute mean motor output [0, 1] from actuator_motors control array.
+def thrust_z_magnitude(thrust_sp_data):
+    """Compute vertical thrust magnitude [0, 1] from vehicle_thrust_setpoint.
 
-    Averages all finite (active) motor channels per sample.
+    Uses |xyz[2]| which is the Z body-axis component (negative = upward in FRD).
+    This matches the firmware compensation signal in VehicleAirData.
     """
-    # Collect all motor channels present in the data
-    channels = []
-    for i in range(12):
-        key = f"control[{i}]"
-        if key in motors_data:
-            channels.append(motors_data[key])
-
-    if not channels:
-        return np.zeros(len(next(iter(motors_data.values()))))
-
-    stack = np.column_stack(channels)  # (N, num_motors)
-    finite_mask = np.isfinite(stack)
-    # Replace NaN with 0 for sum, count only finite
-    safe = np.where(finite_mask, np.clip(stack, 0, 1), 0)
-    counts = finite_mask.sum(axis=1).clip(min=1)
-    return safe.sum(axis=1) / counts
+    z = thrust_sp_data.get("xyz[2]", None)
+    if z is None:
+        return np.zeros(len(next(iter(thrust_sp_data.values()))))
+    return np.where(np.isfinite(z), np.abs(z), 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -187,14 +176,14 @@ def extract_range(ulog):
 
 
 def extract_thrust(ulog):
-    """Extract mean motor thrust from actuator_motors."""
+    """Extract vertical thrust magnitude from vehicle_thrust_setpoint."""
     start_us = ulog.start_timestamp
-    motors = get_topic(ulog, "actuator_motors")
-    if motors is None:
+    thrust_sp = get_topic(ulog, "vehicle_thrust_setpoint")
+    if thrust_sp is None:
         return None
     return {
-        "time_s": us_to_seconds(motors.data["timestamp"], start_us),
-        "thrust": mean_motor_thrust(motors.data),
+        "time_s": us_to_seconds(thrust_sp.data["timestamp"], start_us),
+        "thrust": thrust_z_magnitude(thrust_sp.data),
     }
 
 
@@ -1349,7 +1338,7 @@ def main():
               file=sys.stderr)
         sys.exit(1)
     if thrust_data is None:
-        print("Error: no thrust data (actuator_motors) in log",
+        print("Error: no thrust data (vehicle_thrust_setpoint) in log",
               file=sys.stderr)
         sys.exit(1)
 

--- a/Tools/baro_compensation/baro_thrust_calibration.py
+++ b/Tools/baro_compensation/baro_thrust_calibration.py
@@ -1,0 +1,1586 @@
+#!/usr/bin/env python3
+"""
+Barometer thrust compensation analysis tool.
+
+Analyzes baro thrust compensation from flight logs. Three modes:
+
+1. **Estimator review** (baro_thrust_estimate logged, no range sensor):
+   Shows online estimator convergence, K identification, residual analysis.
+
+2. **Full validation** (baro_thrust_estimate + range sensor):
+   Cross-validates online estimator results against range-sensor ground truth.
+
+3. **Standalone calibration** (range sensor, no estimator):
+   Identifies SENS_BARO_PCOEF from baro vs range error.
+
+The correction model: baro_alt += SENS_BARO_PCOEF * mean_motor_output
+
+Requirements:
+    - Flight log (.ulg)
+    - Python packages: pyulog, numpy, matplotlib
+
+Usage:
+    python3 baro_thrust_calibration.py <log.ulg> [--output-dir <dir>]  (default: /tmp/baro_analysis)
+
+Outputs:
+    - baro_calibration.pdf    Analysis plots
+    - Console output with parameters and diagnostics
+"""
+
+import argparse
+import io
+import os
+import shutil
+import sys
+
+import numpy as np
+
+try:
+    from pyulog import ULog
+except ImportError:
+    print("Error: pyulog not installed. Run: pip install pyulog", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+except ImportError:
+    print("Error: matplotlib not installed. Run: pip install matplotlib", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Layout constants
+# ---------------------------------------------------------------------------
+
+_SUBTITLE_X = 0.5
+_SUBTITLE_Y = 0.94
+_LAYOUT_TOP = 0.93  # top of plot area, just below subtitle
+
+# ---------------------------------------------------------------------------
+# ULog helpers
+# ---------------------------------------------------------------------------
+
+def get_topic(ulog, topic_name, multi_id=0):
+    """Return the first matching dataset for a topic name and multi_id."""
+    for d in ulog.data_list:
+        if d.name == topic_name and d.multi_id == multi_id:
+            return d
+    return None
+
+
+def get_param(ulog, name, default=None):
+    """Get an initial parameter value from the log."""
+    return ulog.initial_parameters.get(name, default)
+
+
+def us_to_seconds(ts_us, start_us):
+    """Convert microsecond timestamps to seconds relative to log start."""
+    return (ts_us.astype(np.int64) - np.int64(start_us)) / 1e6
+
+
+def mean_motor_thrust(motors_data):
+    """Compute mean motor output [0, 1] from actuator_motors control array.
+
+    Averages all finite (active) motor channels per sample.
+    """
+    # Collect all motor channels present in the data
+    channels = []
+    for i in range(12):
+        key = f"control[{i}]"
+        if key in motors_data:
+            channels.append(motors_data[key])
+
+    if not channels:
+        return np.zeros(len(next(iter(motors_data.values()))))
+
+    stack = np.column_stack(channels)  # (N, num_motors)
+    finite_mask = np.isfinite(stack)
+    # Replace NaN with 0 for sum, count only finite
+    safe = np.where(finite_mask, np.clip(stack, 0, 1), 0)
+    counts = finite_mask.sum(axis=1).clip(min=1)
+    return safe.sum(axis=1) / counts
+
+
+# ---------------------------------------------------------------------------
+# Flight phase detection
+# ---------------------------------------------------------------------------
+
+def detect_armed_period(ulog):
+    """Detect armed start/end times from vehicle_status or actuator_motors."""
+    start_us = ulog.start_timestamp
+
+    vstatus = get_topic(ulog, "vehicle_status")
+    if vstatus is not None and "arming_state" in vstatus.data:
+        ts = us_to_seconds(vstatus.data["timestamp"], start_us)
+        armed_idx = np.where(vstatus.data["arming_state"] == 2)[0]
+        if len(armed_idx) > 0:
+            return ts[armed_idx[0]], ts[armed_idx[-1]]
+
+    # Fallback: look for motor activity
+    motors = get_topic(ulog, "actuator_motors")
+    if motors is not None:
+        ts = us_to_seconds(motors.data["timestamp"], start_us)
+        active = np.zeros(len(ts), dtype=bool)
+        for i in range(12):
+            key = f"control[{i}]"
+            if key in motors.data:
+                active |= (motors.data[key] > 0.05)
+        active_idx = np.where(active)[0]
+        if len(active_idx) > 0:
+            return ts[active_idx[0]], ts[active_idx[-1]]
+
+    # Last resort: full log duration
+    return 0.0, (ulog.last_timestamp - start_us) / 1e6
+
+
+def find_hover_segment(armed_start, armed_end):
+    """Return the full armed period as the analysis window.
+
+    Range-based analysis filters by minimum altitude separately
+    to exclude ground proximity, so no time trimming needed here.
+    """
+    return armed_start, armed_end
+
+
+# ---------------------------------------------------------------------------
+# Data extraction
+# ---------------------------------------------------------------------------
+
+def extract_baro(ulog):
+    """Extract barometer altitude from vehicle_air_data.baro_alt_meter."""
+    start_us = ulog.start_timestamp
+    vad = get_topic(ulog, "vehicle_air_data")
+    if vad is None:
+        return None
+    return {
+        "time_s": us_to_seconds(vad.data["timestamp_sample"], start_us),
+        "alt_m": vad.data["baro_alt_meter"],
+    }
+
+
+def extract_ekf_baro_obs(ulog):
+    """Extract baro observation from estimator_aid_src_baro_hgt (NED)."""
+    start_us = ulog.start_timestamp
+    d = get_topic(ulog, "estimator_aid_src_baro_hgt")
+    if d is None:
+        return None
+    return {
+        "time_s": us_to_seconds(d.data["timestamp"], start_us),
+        "observation": d.data["observation"],
+    }
+
+
+def extract_range(ulog):
+    """Extract range sensor distance from distance_sensor."""
+    start_us = ulog.start_timestamp
+    dist = get_topic(ulog, "distance_sensor")
+    if dist is None:
+        return None
+    return {
+        "time_s": us_to_seconds(dist.data["timestamp"], start_us),
+        "distance_m": dist.data["current_distance"],
+    }
+
+
+def extract_thrust(ulog):
+    """Extract mean motor thrust from actuator_motors."""
+    start_us = ulog.start_timestamp
+    motors = get_topic(ulog, "actuator_motors")
+    if motors is None:
+        return None
+    return {
+        "time_s": us_to_seconds(motors.data["timestamp"], start_us),
+        "thrust": mean_motor_thrust(motors.data),
+    }
+
+
+def extract_estimator(ulog):
+    """Extract online estimator state from baro_thrust_estimate."""
+    start_us = ulog.start_timestamp
+    est = get_topic(ulog, "baro_thrust_estimate")
+    if est is None:
+        return None
+    result = {
+        "time_s": us_to_seconds(est.data["timestamp"], start_us),
+        "residual": est.data["residual"],
+        "k_estimate": est.data["k_estimate"],
+        "k_estimate_var": est.data["k_estimate_var"],
+        "error_var": est.data.get("error_var",
+                        np.zeros(len(est.data["timestamp"]))),
+        "thrust_std": est.data["thrust_std"],
+        "converged": est.data["converged"],
+        "estimation_active": est.data["estimation_active"],
+    }
+
+    return result
+
+
+def extract_ekf_z(ulog):
+    """Extract EKF Z position from vehicle_local_position."""
+    start_us = ulog.start_timestamp
+    d = get_topic(ulog, "vehicle_local_position")
+    if d is None:
+        return None
+    return {
+        "time_s": us_to_seconds(d.data["timestamp"], start_us),
+        "z": d.data["z"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+def compute_baro_error(baro, range_data, armed_start):
+    """Compute baro altitude error relative to range sensor.
+
+    Both signals are aligned to a common time base (range sensor timestamps).
+    Baro altitude is zeroed at arm time so it represents change from ground.
+
+    Returns: dict with time_s, baro_error (baro - range, positive = baro reads
+    higher than truth), and the interpolated baro/range arrays.
+    """
+    baro_t, baro_alt = baro["time_s"], baro["alt_m"]
+    rng_t, rng_dist = range_data["time_s"], range_data["distance_m"]
+
+    # Zero baro at arm time
+    arm_baro = np.interp(armed_start, baro_t, baro_alt)
+    baro_zeroed = baro_alt - arm_baro
+
+    # Interpolate baro onto range sensor time base
+    baro_interp = np.interp(rng_t, baro_t, baro_zeroed)
+    error = baro_interp - rng_dist
+
+    return {
+        "time_s": rng_t,
+        "error": error,
+        "baro_alt": baro_interp,
+        "range_alt": rng_dist,
+        "baro_full_time_s": baro_t,
+        "baro_full_alt": baro_zeroed,
+    }
+
+
+def calibrate(baro_err, thrust_data, hover_start, hover_end):
+    """System identification for thrust-based baro compensation.
+
+    Fits: baro_error = K * motor_thrust + c
+    using 2-parameter least squares. The intercept c absorbs any
+    constant baro/range offset.
+
+    Returns dict with identified K, R^2, and recommended PCOEF.
+    """
+    err_t = baro_err["time_s"]
+    err = baro_err["error"]
+
+    # Restrict to analysis window, excluding low altitude (ground proximity)
+    MIN_RANGE_M = 0.5
+    hov = ((err_t >= hover_start) & (err_t <= hover_end)
+           & (baro_err["range_alt"] > MIN_RANGE_M))
+    if hov.sum() < 20:
+        return None
+
+    err_t_hov = err_t[hov]
+    err_hov = err[hov]
+
+    # Interpolate motor thrust onto error timestamps
+    thrust_mag = np.interp(err_t_hov, thrust_data["time_s"],
+                           thrust_data["thrust"])
+
+    err_var = np.var(err_hov)
+    if err_var < 1e-10:
+        return None
+
+    # 2-parameter least squares: err = K * thrust + c
+    A = np.column_stack([thrust_mag, np.ones(len(thrust_mag))])
+    coeffs, _, _, _ = np.linalg.lstsq(A, err_hov, rcond=None)
+    K, c = float(coeffs[0]), float(coeffs[1])
+    residual = err_hov - (K * thrust_mag + c)
+    r2 = 1.0 - np.var(residual) / err_var
+    rmse = float(np.sqrt(np.mean(residual**2)))
+
+    result = {
+        "hover_time": err_t_hov,
+        "hover_error": err_hov,
+        "thrust_mag": thrust_mag,
+        "best_K": K,
+        "best_r2": r2,
+        "best_rmse": rmse,
+        "recommended_pcoef": -K,
+    }
+
+    return result
+
+
+def estimate_open_loop_delay(baro_err, thrust_data, hover_start, hover_end):
+    """Estimate physical motor-to-baro delay, rejecting closed-loop feedback.
+
+    The naive cross-correlation between baro error and motor output includes
+    feedback artifacts: baro_error -> EKF -> controller -> motor.  This path
+    operates below the altitude controller bandwidth (~1-2 Hz).
+
+    By high-pass filtering both signals (subtracting a smoothed version),
+    we isolate motor variation above the controller bandwidth — mostly
+    pilot input and attitude controller, not altitude feedback.  The
+    cross-correlation of these high-passed signals gives the true
+    open-loop physical delay (motor -> pressure -> baro integration).
+
+    Returns dict with open-loop delay estimate, or None if insufficient data.
+    """
+    err_t = baro_err["time_s"]
+    err = baro_err["error"]
+
+    MIN_RANGE_M = 0.5
+    hov = ((err_t >= hover_start) & (err_t <= hover_end)
+           & (baro_err["range_alt"] > MIN_RANGE_M))
+    if hov.sum() < 100:
+        return None
+
+    err_t_hov = err_t[hov]
+    err_hov = err[hov]
+    dt_median = float(np.median(np.diff(err_t_hov)))
+
+    if dt_median <= 0:
+        return None
+
+    # Interpolate motor to error timestamps
+    thrust_hov = np.interp(err_t_hov, thrust_data["time_s"],
+                           thrust_data["thrust"])
+
+    # High-pass filter: subtract moving average to remove feedback loop.
+    # 500ms window ≈ 2Hz cutoff, above altitude controller bandwidth.
+    window = max(3, int(round(0.5 / dt_median)))
+    if window % 2 == 0:
+        window += 1  # odd for symmetric window
+
+    def highpass(sig):
+        # Centered moving average (causal padding to avoid edge shift)
+        kernel = np.ones(window) / window
+        smoothed = np.convolve(sig, kernel, mode="same")
+        return sig - smoothed
+
+    err_hp = highpass(err_hov)
+    thr_hp = highpass(thrust_hov)
+
+    # Check that high-pass signals have meaningful variance
+    if np.std(err_hp) < 1e-6 or np.std(thr_hp) < 1e-6:
+        return None
+
+    result = {}
+
+    # Cross-correlation of high-passed signals
+    err_c = err_hp - np.mean(err_hp)
+    thr_c = thr_hp - np.mean(thr_hp)
+    xcorr = np.correlate(err_c, thr_c, "full")
+    mid = len(thr_c) - 1
+    lags = (np.arange(len(xcorr)) - mid) * dt_median
+    norm = np.sqrt(np.sum(err_c**2) * np.sum(thr_c**2))
+    if norm > 0:
+        xcorr = xcorr / norm
+
+    # Focus on ±500ms window
+    window_mask = (lags >= -0.5) & (lags <= 0.5)
+    lags_w = lags[window_mask]
+    xcorr_w = xcorr[window_mask]
+    peak_idx = np.argmax(np.abs(xcorr_w))
+
+    result["lags_s"] = lags_w
+    result["xcorr"] = xcorr_w
+    result["peak_lag_s"] = float(lags_w[peak_idx])
+    result["peak_r"] = float(xcorr_w[peak_idx])
+    result["hp_window_ms"] = window * dt_median * 1000
+
+    # Lag sweep R² on high-passed signals
+    max_lag = 0.3
+    lag_steps = np.arange(-max_lag, max_lag + dt_median, dt_median)
+    lag_r2 = np.zeros(len(lag_steps))
+
+    err_hp_var = np.var(err_hp)
+    for i, lag in enumerate(lag_steps):
+        thr_shifted = highpass(
+            np.interp(err_t_hov + lag, thrust_data["time_s"],
+                      thrust_data["thrust"]))
+        A = np.column_stack([thr_shifted, np.ones(len(thr_shifted))])
+        c, _, _, _ = np.linalg.lstsq(A, err_hp, rcond=None)
+        resid = err_hp - A @ c
+        lag_r2[i] = 1.0 - np.var(resid) / err_hp_var
+
+    best_idx = np.argmax(lag_r2)
+    result["lag_steps_s"] = lag_steps
+    result["lag_r2"] = lag_r2
+    result["best_lag_s"] = float(lag_steps[best_idx])
+    result["best_lag_r2"] = float(lag_r2[best_idx])
+
+    zero_idx = np.argmin(np.abs(lag_steps))
+    result["zero_lag_r2"] = float(lag_r2[zero_idx])
+
+    return result
+
+
+def diagnose_residual(baro_err, thrust_data, hover_start, hover_end):
+    """Diagnose residual thrust-baro correlation after linear compensation.
+
+    Tests two hypotheses for why a linear K*thrust model leaves residual
+    correlation:
+      1. Time delay — propwash takes time to reach the baro sensor
+      2. Nonlinearity — pressure scales with thrust^2 or similar
+
+    Returns dict with cross-correlation, lag-sweep R², and quadratic fit
+    results, or None if insufficient data.
+    """
+    err_t = baro_err["time_s"]
+    err = baro_err["error"]
+
+    MIN_RANGE_M = 0.5
+    hov = ((err_t >= hover_start) & (err_t <= hover_end)
+           & (baro_err["range_alt"] > MIN_RANGE_M))
+    if hov.sum() < 50:
+        return None
+
+    err_t_hov = err_t[hov]
+    err_hov = err[hov]
+    thrust_mag = np.interp(err_t_hov, thrust_data["time_s"],
+                           thrust_data["thrust"])
+
+    err_var = np.var(err_hov)
+    if err_var < 1e-10:
+        return None
+
+    result = {}
+
+    # --- Cross-correlation ---
+    err_centered = err_hov - np.mean(err_hov)
+    thrust_centered = thrust_mag - np.mean(thrust_mag)
+    dt_median = float(np.median(np.diff(err_t_hov)))
+
+    if dt_median > 0 and len(err_centered) > 20:
+        xcorr = np.correlate(err_centered, thrust_centered, "full")
+        mid = len(thrust_centered) - 1
+        lags = (np.arange(len(xcorr)) - mid) * dt_median
+        norm = np.sqrt(np.sum(err_centered**2) * np.sum(thrust_centered**2))
+        if norm > 0:
+            xcorr = xcorr / norm
+        window = (lags >= -2.0) & (lags <= 2.0)
+        result["xcorr_lags_s"] = lags[window]
+        result["xcorr_values"] = xcorr[window]
+        peak_idx = np.argmax(np.abs(xcorr[window]))
+        result["xcorr_peak_lag_s"] = float(lags[window][peak_idx])
+        result["xcorr_peak_value"] = float(xcorr[window][peak_idx])
+
+    # --- Lag sweep: fit K at various time shifts, track R² ---
+    max_lag_s = 1.0
+    lag_steps = np.arange(-max_lag_s, max_lag_s + dt_median, dt_median)
+    lag_r2 = np.zeros(len(lag_steps))
+    lag_K = np.zeros(len(lag_steps))
+
+    for i, lag in enumerate(lag_steps):
+        thrust_shifted = np.interp(err_t_hov + lag, thrust_data["time_s"],
+                                   thrust_data["thrust"])
+        A = np.column_stack([thrust_shifted, np.ones(len(thrust_shifted))])
+        coeffs, _, _, _ = np.linalg.lstsq(A, err_hov, rcond=None)
+        resid = err_hov - A @ coeffs
+        lag_r2[i] = 1.0 - np.var(resid) / err_var
+        lag_K[i] = float(coeffs[0])
+
+    best_lag_idx = np.argmax(lag_r2)
+    result["lag_steps_s"] = lag_steps
+    result["lag_r2"] = lag_r2
+    result["lag_K"] = lag_K
+    result["best_lag_s"] = float(lag_steps[best_lag_idx])
+    result["best_lag_r2"] = float(lag_r2[best_lag_idx])
+    result["best_lag_K"] = float(lag_K[best_lag_idx])
+
+    # Zero-lag R² for comparison
+    zero_idx = np.argmin(np.abs(lag_steps))
+    result["zero_lag_r2"] = float(lag_r2[zero_idx])
+
+    # --- Quadratic fit: err = a*thrust^2 + b*thrust + c ---
+    A_quad = np.column_stack([thrust_mag**2, thrust_mag, np.ones(len(thrust_mag))])
+    coeffs_quad, _, _, _ = np.linalg.lstsq(A_quad, err_hov, rcond=None)
+    resid_quad = err_hov - A_quad @ coeffs_quad
+    result["quad_r2"] = float(1.0 - np.var(resid_quad) / err_var)
+    result["quad_coeffs"] = [float(c) for c in coeffs_quad]  # [a, b, c]
+
+    # Linear R² for comparison
+    A_lin = np.column_stack([thrust_mag, np.ones(len(thrust_mag))])
+    coeffs_lin, _, _, _ = np.linalg.lstsq(A_lin, err_hov, rcond=None)
+    resid_lin = err_hov - A_lin @ coeffs_lin
+    result["linear_r2"] = float(1.0 - np.var(resid_lin) / err_var)
+
+    # --- Combined: lag + quadratic ---
+    if result["best_lag_s"] != 0:
+        thrust_best_lag = np.interp(err_t_hov + result["best_lag_s"],
+                                    thrust_data["time_s"],
+                                    thrust_data["thrust"])
+        A_comb = np.column_stack([thrust_best_lag**2, thrust_best_lag,
+                                  np.ones(len(thrust_best_lag))])
+        coeffs_comb, _, _, _ = np.linalg.lstsq(A_comb, err_hov, rcond=None)
+        resid_comb = err_hov - A_comb @ coeffs_comb
+        result["combined_r2"] = float(1.0 - np.var(resid_comb) / err_var)
+    else:
+        result["combined_r2"] = result["quad_r2"]
+
+    result["thrust_mag"] = thrust_mag
+    result["err_hov"] = err_hov
+    result["err_t_hov"] = err_t_hov
+
+    return result
+
+
+def plot_residual_diagnostics(diag, calib):
+    """Diagnostic page: cross-correlation, lag sweep, and nonlinearity test."""
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10))
+    fig.suptitle("Residual Correlation Diagnostics",
+                 fontsize=14, fontweight="bold")
+    fig.text(_SUBTITLE_X, _SUBTITLE_Y,
+             "Why does residual correlation remain after linear compensation? "
+             "Left: time delay analysis. Right: nonlinearity analysis.",
+             ha="center", va="top", fontsize=9, style="italic", color="0.4")
+
+    # Top-left: Cross-correlation
+    ax = axes[0, 0]
+    if "xcorr_lags_s" in diag:
+        ax.plot(diag["xcorr_lags_s"] * 1000, diag["xcorr_values"],
+                color="tab:blue", linewidth=1.0)
+        peak_lag = diag["xcorr_peak_lag_s"]
+        peak_val = diag["xcorr_peak_value"]
+        ax.axvline(peak_lag * 1000, color="tab:red", linestyle="--",
+                   linewidth=0.8,
+                   label=f"Peak: {peak_lag*1000:+.0f}ms (r={peak_val:.3f})")
+        ax.axvline(0, color="k", linewidth=0.5, linestyle=":")
+    ax.set_xlabel("Lag [ms]  (positive = thrust leads error)")
+    ax.set_ylabel("Normalized cross-correlation")
+    ax.set_title("Cross-Correlation: Baro Error vs Thrust")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Bottom-left: Lag sweep R²
+    ax = axes[1, 0]
+    ax.plot(diag["lag_steps_s"] * 1000, diag["lag_r2"],
+            color="tab:blue", linewidth=1.0)
+    best_lag = diag["best_lag_s"]
+    best_r2 = diag["best_lag_r2"]
+    zero_r2 = diag["zero_lag_r2"]
+    ax.axvline(best_lag * 1000, color="tab:red", linestyle="--", linewidth=0.8,
+               label=f"Best lag: {best_lag*1000:+.0f}ms "
+                     f"(R\u00b2={best_r2:.3f}, K={diag['best_lag_K']:.1f})")
+    ax.axvline(0, color="k", linewidth=0.5, linestyle=":")
+    ax.axhline(zero_r2, color="tab:gray", linestyle=":", linewidth=0.8,
+               label=f"Zero lag R\u00b2={zero_r2:.3f}")
+    ax.set_xlabel("Thrust time shift [ms]")
+    ax.set_ylabel("R\u00b2")
+    ax.set_title("Lag Sweep: R\u00b2 vs Thrust Time Shift")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Top-right: Linear vs quadratic scatter
+    ax = axes[0, 1]
+    thrust = diag["thrust_mag"]
+    err = diag["err_hov"]
+    ax.scatter(thrust, err, s=2, alpha=0.3, color="tab:orange")
+
+    x_fit = np.linspace(thrust.min(), thrust.max(), 100)
+    # Linear fit line
+    lin_coeffs = np.polyfit(thrust, err, 1)
+    ax.plot(x_fit, np.polyval(lin_coeffs, x_fit), "k--", linewidth=1.2,
+            label=f"Linear (R\u00b2={diag['linear_r2']:.3f})")
+    # Quadratic fit line
+    a, b, c = diag["quad_coeffs"]
+    ax.plot(x_fit, a * x_fit**2 + b * x_fit + c, "r-", linewidth=1.2,
+            label=f"Quadratic (R\u00b2={diag['quad_r2']:.3f})")
+    ax.set_xlabel("Thrust [0-1]")
+    ax.set_ylabel("Baro Error [m]")
+    ax.set_title("Linear vs Quadratic Fit")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Bottom-right: Summary text
+    ax = axes[1, 1]
+    ax.axis("off")
+
+    r2_gain_lag = diag["best_lag_r2"] - diag["zero_lag_r2"]
+    r2_gain_quad = diag["quad_r2"] - diag["linear_r2"]
+    r2_gain_comb = diag["combined_r2"] - diag["linear_r2"]
+
+    lines = [
+        "Residual Diagnostics",
+        "",
+        "  Model R\u00b2 comparison:",
+        f"    Linear (zero lag):     {diag['linear_r2']:.3f}",
+        f"    Linear (best lag):     {diag['best_lag_r2']:.3f}"
+        f"  (+{r2_gain_lag:.3f})",
+        f"    Quadratic (zero lag):  {diag['quad_r2']:.3f}"
+        f"  (+{r2_gain_quad:.3f})",
+        f"    Quadratic + best lag:  {diag['combined_r2']:.3f}"
+        f"  (+{r2_gain_comb:.3f})",
+        "",
+        f"  Optimal lag: {diag['best_lag_s']*1000:+.0f}ms",
+        "",
+    ]
+
+    # Interpretation
+    if r2_gain_lag > 0.05 and r2_gain_quad < 0.02:
+        lines.append("  >> Time delay is the dominant factor.")
+        lines.append(f"     Shifting thrust by {diag['best_lag_s']*1000:+.0f}ms")
+        lines.append(f"     improves R\u00b2 by {r2_gain_lag:.3f}.")
+    elif r2_gain_quad > 0.05 and r2_gain_lag < 0.02:
+        lines.append("  >> Nonlinearity is the dominant factor.")
+        lines.append("     Consider a quadratic thrust model.")
+    elif r2_gain_lag > 0.02 and r2_gain_quad > 0.02:
+        lines.append("  >> Both delay and nonlinearity contribute.")
+        lines.append(f"     Combined R\u00b2 gain: +{r2_gain_comb:.3f}")
+    else:
+        lines.append("  >> Neither delay nor nonlinearity explain")
+        lines.append("     the residual. Other factors at play")
+        lines.append("     (e.g., altitude-dependent effect,")
+        lines.append("     wind, ground effect).")
+
+    ax.text(0.05, 0.95, "\n".join(lines), transform=ax.transAxes,
+            fontsize=11, verticalalignment="top", family="monospace",
+            bbox=dict(boxstyle="round,pad=0.5", facecolor="#f0f0f0",
+                      edgecolor="#cccccc"))
+
+    plt.tight_layout(rect=[0, 0, 1, _LAYOUT_TOP])
+    return fig
+
+
+def plot_open_loop_delay(ol):
+    """Plot open-loop delay analysis (feedback-rejected)."""
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+    fig.suptitle("Open-Loop Delay Analysis (Feedback-Rejected)",
+                 fontsize=14, fontweight="bold")
+    fig.text(_SUBTITLE_X, _SUBTITLE_Y,
+             "High-pass filtered to remove altitude controller feedback. "
+             "Shows true physical motor-to-baro delay.",
+             ha="center", va="top", fontsize=9, style="italic", color="0.4")
+
+    # Left: Cross-correlation
+    ax = axes[0]
+    ax.plot(ol["lags_s"] * 1000, ol["xcorr"],
+            color="tab:blue", linewidth=1.0)
+    peak_lag = ol["peak_lag_s"]
+    peak_r = ol["peak_r"]
+    ax.axvline(peak_lag * 1000, color="tab:red", linestyle="--", linewidth=0.8,
+               label=f"Peak: {peak_lag*1000:+.0f}ms (r={peak_r:.3f})")
+    ax.axvline(0, color="k", linewidth=0.5, linestyle=":")
+    ax.set_xlabel("Lag [ms]  (positive = thrust leads error)")
+    ax.set_ylabel("Normalized cross-correlation")
+    ax.set_title("High-Pass Cross-Correlation")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Right: Lag sweep R²
+    ax = axes[1]
+    ax.plot(ol["lag_steps_s"] * 1000, ol["lag_r2"],
+            color="tab:blue", linewidth=1.0)
+    best_lag = ol["best_lag_s"]
+    best_r2 = ol["best_lag_r2"]
+    zero_r2 = ol["zero_lag_r2"]
+    ax.axvline(best_lag * 1000, color="tab:red", linestyle="--", linewidth=0.8,
+               label=f"Best lag: {best_lag*1000:+.0f}ms (R\u00b2={best_r2:.3f})")
+    ax.axvline(0, color="k", linewidth=0.5, linestyle=":")
+    ax.axhline(zero_r2, color="tab:gray", linestyle=":", linewidth=0.8,
+               label=f"Zero lag R\u00b2={zero_r2:.3f}")
+    ax.set_xlabel("Thrust time shift [ms]")
+    ax.set_ylabel("R\u00b2")
+    ax.set_title("High-Pass Lag Sweep")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout(rect=[0, 0, 1, _LAYOUT_TOP])
+    return fig
+
+
+def plot_summary_text(text_lines):
+    """Final page: full console output summary."""
+    fig, ax = plt.subplots(1, 1, figsize=(14, 10))
+    ax.axis("off")
+    fig.suptitle("Analysis Summary", fontsize=14, fontweight="bold")
+    ax.text(0.02, 0.98, "\n".join(text_lines), transform=ax.transAxes,
+            fontsize=10, verticalalignment="top", family="monospace",
+            bbox=dict(boxstyle="round,pad=0.5", facecolor="#f8f8f8",
+                      edgecolor="#cccccc"))
+    plt.tight_layout(rect=[0, 0, 1, 0.95])
+    return fig
+
+
+def reconstruct_raw_error(baro_err, thrust_data, pcoef):
+    """Undo existing baro compensation to reconstruct the raw error.
+
+    During flight the firmware applied at baro timestamps:
+        baro_alt += pcoef * motor_at(baro_timestamp_sample)
+    To preserve timing fidelity, undo at the original baro timestamps,
+    then re-interpolate to the range sensor time base.
+    """
+    baro_t = baro_err["baro_full_time_s"]
+    baro_alt = baro_err["baro_full_alt"]
+
+    # Undo compensation at baro timestamps (matching firmware time-alignment)
+    thrust_at_baro = np.interp(baro_t, thrust_data["time_s"],
+                               thrust_data["thrust"])
+    raw_baro = baro_alt - pcoef * thrust_at_baro
+
+    # Re-interpolate raw baro to range sensor time base
+    rng_t = baro_err["time_s"]
+    raw_baro_interp = np.interp(rng_t, baro_t, raw_baro)
+    raw_error = raw_baro_interp - baro_err["range_alt"]
+
+    result = dict(baro_err)
+    result["error"] = raw_error
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Plotting — overview and range-based pages
+# ---------------------------------------------------------------------------
+
+def plot_altitude_overview(ekf_baro_obs, ekf_z, range_data, thrust_data,
+                          armed_start, armed_end):
+    """Altitude overview — baro observation, EKF Z, and distance sensor."""
+    fig, axes = plt.subplots(2, 1, figsize=(14, 8), sharex=True)
+    fig.suptitle("Altitude Overview", fontsize=14, fontweight="bold")
+    fig.text(_SUBTITLE_X, _SUBTITLE_Y,
+             "Baro altitude vs EKF and range sensor. "
+             "Gap between baro and range reveals propwash-induced pressure error.",
+             ha="center", va="top", fontsize=9, style="italic", color="0.4")
+
+    ax = axes[0]
+
+    # Distance sensor (ground truth, if available)
+    if range_data is not None:
+        ax.plot(range_data["time_s"], range_data["distance_m"],
+                label="Distance sensor", color="tab:blue", linewidth=1.2)
+
+    # Baro observation (estimator_aid_src_baro_hgt, inverted NED, zeroed at arm)
+    if ekf_baro_obs is not None:
+        baro_t = ekf_baro_obs["time_s"]
+        baro_alt = -ekf_baro_obs["observation"]  # NED to altitude-up
+        arm_baro = np.interp(armed_start, baro_t, baro_alt)
+        baro_zeroed = baro_alt - arm_baro
+        ax.plot(baro_t, baro_zeroed,
+                label="Baro observation", color="tab:red",
+                linewidth=1.0, alpha=0.8)
+
+    # EKF Z (inverted NED -> altitude up, zeroed at arm)
+    if ekf_z is not None:
+        ekf_t = ekf_z["time_s"]
+        ekf_alt = -ekf_z["z"]  # NED to altitude-up
+        arm_ekf = np.interp(armed_start, ekf_t, ekf_alt)
+        ekf_zeroed = ekf_alt - arm_ekf
+        ax.plot(ekf_t, ekf_zeroed,
+                label="EKF altitude (-Z)", color="tab:green",
+                linewidth=1.0, alpha=0.8)
+
+    ax.axvspan(armed_start, armed_end, alpha=0.04, color="green", label="Armed")
+    ax.set_ylabel("Altitude AGL [m]")
+    ax.legend(loc="upper left", fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Thrust
+    ax = axes[1]
+    if thrust_data is not None:
+        thr_t = thrust_data["time_s"]
+        thr_mag = thrust_data["thrust"]
+        ax.plot(thr_t, thr_mag, color="tab:orange", linewidth=0.8,
+                label="Thrust magnitude")
+    ax.set_ylabel("Thrust [0-1]")
+    ax.set_xlabel("Time [s]")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout(rect=[0, 0, 1, _LAYOUT_TOP])
+    return fig
+
+
+def plot_compensation_comparison(baro_err, thrust_data, calib, online_k,
+                                 armed_start, armed_end,
+                                 existing_pcoef=0.0):
+    """Side-by-side baro vs range: online-corrected vs offline-corrected."""
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10), sharex=True)
+    fig.suptitle("Compensation Comparison: Online vs Offline",
+                 fontsize=14, fontweight="bold")
+    fig.text(_SUBTITLE_X, _SUBTITLE_Y,
+             "Left: baro corrected using online estimator K. "
+             "Right: corrected using offline calibration (range-sensor ground truth).\n"
+             "Closer baro-range agreement = better compensation.",
+             ha="center", va="top", fontsize=9, style="italic", color="0.4")
+
+    t = baro_err["time_s"]
+    err = baro_err["error"]
+    baro_t = baro_err["baro_full_time_s"]
+    baro_alt = baro_err["baro_full_alt"]
+
+    # Reconstruct raw error/altitude by undoing any existing compensation.
+    # baro_alt and err reflect the as-flown data (with existing_pcoef applied).
+    thr_mag = np.interp(t, thrust_data["time_s"], thrust_data["thrust"])
+    raw_err = err - existing_pcoef * thr_mag
+
+    thr_full = np.interp(baro_t, thrust_data["time_s"], thrust_data["thrust"])
+    raw_baro = baro_alt - existing_pcoef * thr_full
+
+    # Online: total PCOEF = existing + (-online_k)
+    online_delta = -online_k
+    online_total_pcoef = existing_pcoef + online_delta
+    online_err = raw_err + online_total_pcoef * thr_mag
+    baro_online = raw_baro + online_total_pcoef * thr_full
+    baro_online -= np.interp(armed_start, baro_t, baro_online)
+
+    # Offline: apply identified K (calibrate ran on raw error, so -K is total PCOEF)
+    offline_total_pcoef = -calib["best_K"]
+    offline_delta = offline_total_pcoef - existing_pcoef
+    offline_err = raw_err + offline_total_pcoef * thr_mag
+    baro_offline = raw_baro + offline_total_pcoef * thr_full
+    baro_offline -= np.interp(armed_start, baro_t, baro_offline)
+
+    armed = (baro_t >= armed_start) & (baro_t <= armed_end)
+    armed_r = (t >= armed_start) & (t <= armed_end)
+
+    # Top-left: Online-corrected altitude
+    ax = axes[0, 0]
+    ax.plot(t, baro_err["range_alt"], color="tab:green", linewidth=1.2,
+            label="Range sensor")
+    ax.plot(baro_t[armed], baro_online[armed], color="tab:blue", linewidth=1.0,
+            alpha=0.85,
+            label=f"Baro + online (PCOEF={existing_pcoef:+.1f}+({online_delta:+.1f})={online_total_pcoef:+.1f})")
+    ax.set_ylabel("Altitude [m]")
+    ax.legend(fontsize=10)
+    ax.set_title("Online Estimator Correction")
+    ax.grid(True, alpha=0.3)
+
+    # Top-right: Offline-corrected altitude
+    ax = axes[0, 1]
+    ax.plot(t, baro_err["range_alt"], color="tab:green", linewidth=1.2,
+            label="Range sensor")
+    ax.plot(baro_t[armed], baro_offline[armed], color="tab:blue", linewidth=1.0,
+            alpha=0.85,
+            label=f"Baro + offline (PCOEF={existing_pcoef:+.1f}+({offline_delta:+.1f})={offline_total_pcoef:+.1f})")
+    ax.set_ylabel("Altitude [m]")
+    ax.legend(fontsize=10)
+    ax.set_title("Offline Calibration Correction")
+    ax.grid(True, alpha=0.3)
+
+    # Sync Y-axis limits
+    ylim = [min(axes[0, 0].get_ylim()[0], axes[0, 1].get_ylim()[0]),
+            max(axes[0, 0].get_ylim()[1], axes[0, 1].get_ylim()[1])]
+    axes[0, 0].set_ylim(ylim)
+    axes[0, 1].set_ylim(ylim)
+
+    # Bottom-left: Online residual error
+    ax = axes[1, 0]
+    ax.plot(t[armed_r], online_err[armed_r], color="tab:blue", linewidth=0.8)
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--")
+    online_std = float(np.std(online_err[armed_r]))
+    online_mean = float(np.mean(online_err[armed_r]))
+    ax.set_title(f"Residual Error: mean={online_mean:+.2f}m, std={online_std:.2f}m")
+    ax.set_ylabel("Baro Error [m]")
+    ax.set_xlabel("Time [s]")
+    ax.grid(True, alpha=0.3)
+
+    # Bottom-right: Offline residual error
+    ax = axes[1, 1]
+    ax.plot(t[armed_r], offline_err[armed_r], color="tab:blue", linewidth=0.8)
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--")
+    offline_std = float(np.std(offline_err[armed_r]))
+    offline_mean = float(np.mean(offline_err[armed_r]))
+    ax.set_title(f"Residual Error: mean={offline_mean:+.2f}m, std={offline_std:.2f}m")
+    ax.set_ylabel("Baro Error [m]")
+    ax.set_xlabel("Time [s]")
+    ax.grid(True, alpha=0.3)
+
+    # Sync bottom Y-axis limits
+    ylim = [min(axes[1, 0].get_ylim()[0], axes[1, 1].get_ylim()[0]),
+            max(axes[1, 0].get_ylim()[1], axes[1, 1].get_ylim()[1])]
+    axes[1, 0].set_ylim(ylim)
+    axes[1, 1].set_ylim(ylim)
+
+    plt.tight_layout(rect=[0, 0, 1, _LAYOUT_TOP])
+    return fig
+
+
+def plot_online_vs_offline(baro_err, thrust_data, calib, online_k,
+                           armed_start, armed_end,
+                           existing_pcoef=0.0):
+    """Scatter comparison and summary: online vs offline calibration."""
+    fig, axes = plt.subplots(1, 3, figsize=(16, 6.5))
+    fig.suptitle("Online vs Offline: Error vs Thrust",
+                 fontsize=14, fontweight="bold")
+    fig.text(_SUBTITLE_X, _SUBTITLE_Y,
+             "Scatter plots show baro-range error vs thrust. "
+             "Good compensation removes the thrust correlation (flat scatter near zero).",
+             ha="center", va="top", fontsize=9, style="italic", color="0.4")
+
+    t = baro_err["time_s"]
+    err = baro_err["error"]
+    armed = (t >= armed_start) & (t <= armed_end)
+    t_a = t[armed]
+    err_a = err[armed]
+
+    # Reconstruct raw error by undoing existing compensation
+    thr_mag = np.interp(t_a, thrust_data["time_s"], thrust_data["thrust"])
+    x_fit = np.linspace(thr_mag.min(), thr_mag.max(), 50)
+
+    raw_err = err_a - existing_pcoef * thr_mag
+
+    # Left: Raw error
+    ax = axes[0]
+    ax.scatter(thr_mag, raw_err, s=2, alpha=0.3, color="tab:orange")
+    z_lin = np.polyfit(thr_mag, raw_err, 1)
+    z_quad = np.polyfit(thr_mag, raw_err, 2)
+    ax.plot(x_fit, np.polyval(z_lin, x_fit), "k--", linewidth=1.2, label="Linear")
+    ax.plot(x_fit, np.polyval(z_quad, x_fit), "r-", linewidth=1.0, alpha=0.7, label="Quadratic")
+    r_val = _safe_corrcoef(thr_mag, raw_err)
+    ax.set_title(f"Raw (no compensation)\nr={r_val:.3f}, slope={z_lin[0]:.1f}")
+    ax.set_xlabel("Thrust [0-1]")
+    ax.set_ylabel("Baro Error [m]")
+    ax.legend(fontsize=10)
+    ax.grid(True, alpha=0.3)
+
+    # Middle: Online-corrected (total PCOEF = existing + (-online_k))
+    online_delta = -online_k
+    online_total_pcoef = existing_pcoef + online_delta
+    online_err = raw_err + online_total_pcoef * thr_mag
+    ax = axes[1]
+    ax.scatter(thr_mag, online_err, s=2, alpha=0.3, color="tab:blue")
+    z_lin = np.polyfit(thr_mag, online_err, 1)
+    z_quad = np.polyfit(thr_mag, online_err, 2)
+    ax.plot(x_fit, np.polyval(z_lin, x_fit), "k--", linewidth=1.2, label="Linear")
+    ax.plot(x_fit, np.polyval(z_quad, x_fit), "r-", linewidth=1.0, alpha=0.7, label="Quadratic")
+    r_val = _safe_corrcoef(thr_mag, online_err)
+    ax.set_title(f"Online: {existing_pcoef:+.1f} + ({online_delta:+.1f})"
+                 f" = {online_total_pcoef:+.1f}\n"
+                 f"r={r_val:.3f}, slope={z_lin[0]:.1f}")
+    ax.set_xlabel("Thrust [0-1]")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.3)
+    ax.legend(fontsize=10)
+    ax.grid(True, alpha=0.3)
+
+    # Right: Offline-corrected (calibrate ran on raw error, -K is total PCOEF)
+    offline_total = -calib["best_K"]
+    offline_delta = offline_total - existing_pcoef
+    offline_err = raw_err + offline_total * thr_mag
+    ax = axes[2]
+    ax.scatter(thr_mag, offline_err, s=2, alpha=0.3, color="tab:green")
+    z_lin = np.polyfit(thr_mag, offline_err, 1)
+    z_quad = np.polyfit(thr_mag, offline_err, 2)
+    ax.plot(x_fit, np.polyval(z_lin, x_fit), "k--", linewidth=1.2, label="Linear")
+    ax.plot(x_fit, np.polyval(z_quad, x_fit), "r-", linewidth=1.0, alpha=0.7, label="Quadratic")
+    r_val = _safe_corrcoef(thr_mag, offline_err)
+    ax.set_title(f"Offline: {existing_pcoef:+.1f} + ({offline_delta:+.1f})"
+                 f" = {offline_total:+.1f}\n"
+                 f"r={r_val:.3f}, slope={z_lin[0]:.1f}")
+    ax.set_xlabel("Thrust [0-1]")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.3)
+    ax.legend(fontsize=10)
+    ax.grid(True, alpha=0.3)
+
+    # Sync Y-axis
+    ylim = [min(ax.get_ylim()[0] for ax in axes),
+            max(ax.get_ylim()[1] for ax in axes)]
+    for ax in axes:
+        ax.set_ylim(ylim)
+
+    plt.tight_layout(rect=[0, 0, 1, _LAYOUT_TOP])
+    return fig
+
+
+
+# ---------------------------------------------------------------------------
+# Plotting — online estimator review
+# ---------------------------------------------------------------------------
+
+def plot_estimator_convergence(est_data, armed_start, armed_end,
+                               existing_pcoef=0.0):
+    """Estimator convergence: K estimate, error variance, convergence status."""
+    fig, axes = plt.subplots(3, 1, figsize=(14, 10), sharex=True)
+    fig.suptitle("Online Estimator Convergence", fontsize=14, fontweight="bold")
+    fig.text(_SUBTITLE_X, _SUBTITLE_Y,
+             "RLS estimator progress. K should stabilize before convergence locks. "
+             "Sufficient thrust excitation (std > 0.05) is required.",
+             ha="center", va="top", fontsize=9, style="italic", color="0.4")
+
+    t = est_data["time_s"]
+    armed = (t >= armed_start) & (t <= armed_end)
+    ta = t[armed]
+
+    # Panel 1: K estimate with variance band
+    ax = axes[0]
+    k = est_data["k_estimate"][armed]
+    k_std = np.sqrt(np.clip(est_data["k_estimate_var"][armed], 0, None))
+    ax.plot(ta, k, color="tab:blue", linewidth=1.0, label="K estimate")
+    ax.fill_between(ta, k - k_std, k + k_std, alpha=0.15, color="tab:blue",
+                    label="\u00b11\u03c3")
+    if existing_pcoef != 0.0:
+        ax.axhline(-existing_pcoef, color="tab:red", linestyle="--",
+                   linewidth=0.8, label=f"Saved PCOEF = {existing_pcoef:+.1f}")
+    ax.set_ylabel("K [m/unit thrust]")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Panel 2: Prediction error variance + thrust excitation
+    ax = axes[1]
+    ax.plot(ta, est_data["error_var"][armed], color="tab:orange",
+            linewidth=0.8, label="Error variance")
+    ax.set_ylabel("Error Var / Thrust Std")
+    ax2 = ax.twinx()
+    ax2.plot(ta, est_data["thrust_std"][armed], color="tab:purple",
+             linewidth=0.8, alpha=0.7, label="Thrust std")
+    ax2.set_ylabel("Thrust Std", color="tab:purple")
+    lines1, labels1 = ax.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax.legend(lines1 + lines2, labels1 + labels2, fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    # Panel 3: Convergence + estimation active flags
+    ax = axes[2]
+    conv = est_data["converged"][armed].astype(float)
+    active = est_data["estimation_active"][armed].astype(float)
+    ax.fill_between(ta, 0, active * 0.5, alpha=0.3, color="tab:blue",
+                    step="post", label="Estimation active")
+    ax.fill_between(ta, 0.5, 0.5 + conv * 0.5, alpha=0.4, color="tab:green",
+                    step="post", label="Converged")
+    ax.set_ylim(-0.05, 1.05)
+    ax.set_yticks([0, 0.5, 1.0])
+    ax.set_yticklabels(["", "", ""])
+    ax.set_xlabel("Time [s]")
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout(rect=[0, 0, 1, _LAYOUT_TOP])
+    return fig
+
+
+def plot_estimator_residual(est_data, thrust_data, armed_start, armed_end):
+    """Estimator residual analysis: residual vs time and vs thrust."""
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+    fig.suptitle("CF Residual Analysis (Online Estimator)",
+                 fontsize=14, fontweight="bold")
+
+    t = est_data["time_s"]
+    armed = (t >= armed_start) & (t <= armed_end)
+
+    residual = est_data["residual"][armed]
+    ta = t[armed]
+
+    # Left: Residual time series
+    ax = axes[0]
+    ax.plot(ta, residual, color="tab:red", linewidth=0.6, alpha=0.7)
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--")
+    ax.set_xlabel("Time [s]")
+    ax.set_ylabel("CF Residual [m]")
+    ax.set_title("Residual (Baro - Accel Prediction)")
+    ax.grid(True, alpha=0.3)
+
+    # Right: Residual vs thrust scatter
+    ax = axes[1]
+    if thrust_data is not None:
+        thr_interp = np.interp(ta, thrust_data["time_s"], thrust_data["thrust"])
+        ax.scatter(thr_interp, residual, s=2, alpha=0.3, color="tab:orange")
+        if np.std(thr_interp) > 1e-6:
+            z = np.polyfit(thr_interp, residual, 1)
+            x_fit = np.linspace(thr_interp.min(), thr_interp.max(), 50)
+            ax.plot(x_fit, np.polyval(z, x_fit), "k--", linewidth=1.2)
+            r_val = _safe_corrcoef(thr_interp, residual)
+            ax.set_title(f"Residual vs Thrust\n"
+                         f"r = {r_val:.3f},  slope = {z[0]:.2f} m/unit")
+        else:
+            ax.set_title("Residual vs Thrust")
+    ax.set_xlabel("Thrust magnitude [0-1]")
+    ax.set_ylabel("CF Residual [m]")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.3)
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    return fig
+
+
+def plot_compensation_effect(est_data, thrust_data, armed_start, armed_end):
+    """Compensation effect: CF residual before/after applying estimated K."""
+    t = est_data["time_s"]
+    armed = (t >= armed_start) & (t <= armed_end)
+    ta = t[armed]
+    residual = est_data["residual"][armed]
+
+    # Use converged K, or last value if not converged
+    conv_mask = (est_data["converged"][armed] > 0)
+    if conv_mask.any():
+        idx = np.where(conv_mask)[0][0]
+        final_k = float(est_data["k_estimate"][armed][idx])
+    else:
+        final_k = float(est_data["k_estimate"][armed][-1])
+
+    thrust_mag = np.interp(ta, thrust_data["time_s"], thrust_data["thrust"])
+    corrected = residual - final_k * thrust_mag
+
+    # Remove DC bias for visualization. The RLS model is residual = K*thrust + bias;
+    # the firmware only corrects K*thrust (EKF absorbs the constant offset), so the
+    # corrected signal retains the bias. Subtracting it here lets us visually compare
+    # the thrust-correlated variation before vs after.
+    bias = float(np.mean(corrected))
+    corrected_centered = corrected - bias
+
+    fig, axes = plt.subplots(2, 2, figsize=(14, 10))
+    fig.suptitle("Estimated Compensation Effect", fontsize=14, fontweight="bold")
+    fig.text(_SUBTITLE_X, _SUBTITLE_Y,
+             "CF residual (baro minus accel-predicted altitude) before and after "
+             "applying the online K estimate. Corrected residual should be flat with "
+             "no thrust correlation. DC bias removed for comparison.",
+             ha="center", va="top", fontsize=9, style="italic", color="0.4")
+
+    # Top-left: Residual before/after
+    ax = axes[0, 0]
+    ax.plot(ta, residual, color="tab:red", linewidth=0.6, alpha=0.7,
+            label="Raw CF residual")
+    ax.plot(ta, corrected_centered, color="tab:blue", linewidth=0.6, alpha=0.7,
+            label=f"Corrected (K={final_k:.2f}, bias={bias:+.1f}m removed)")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--")
+    ax.set_ylabel("Residual [m]")
+    ax.set_xlabel("Time [s]")
+    ax.legend(fontsize=9)
+    ax.set_title("CF Residual Before/After Compensation")
+    ax.grid(True, alpha=0.3)
+
+    # Top-right: Scatter — raw residual vs thrust
+    ax = axes[0, 1]
+    ax.scatter(thrust_mag, residual, s=2, alpha=0.3, color="tab:orange")
+    if np.std(thrust_mag) > 1e-6:
+        z = np.polyfit(thrust_mag, residual, 1)
+        x_fit = np.linspace(thrust_mag.min(), thrust_mag.max(), 50)
+        ax.plot(x_fit, np.polyval(z, x_fit), "k--", linewidth=1.2)
+        r_val = _safe_corrcoef(thrust_mag, residual)
+        ax.set_title(f"Raw Residual vs Thrust\nr = {r_val:.3f}")
+    else:
+        ax.set_title("Raw Residual vs Thrust")
+    ax.set_xlabel("Thrust [0-1]")
+    ax.set_ylabel("CF Residual [m]")
+    ax.grid(True, alpha=0.3)
+
+    # Bottom-left: Scatter — corrected residual vs thrust
+    ax = axes[1, 0]
+    ax.scatter(thrust_mag, corrected_centered, s=2, alpha=0.3, color="tab:blue")
+    if np.std(thrust_mag) > 1e-6:
+        z = np.polyfit(thrust_mag, corrected_centered, 1)
+        x_fit = np.linspace(thrust_mag.min(), thrust_mag.max(), 50)
+        ax.plot(x_fit, np.polyval(z, x_fit), "k--", linewidth=1.2)
+        r_val = _safe_corrcoef(thrust_mag, corrected_centered)
+        ax.set_title(f"Corrected Residual vs Thrust\nr = {r_val:.3f}")
+    else:
+        ax.set_title("Corrected Residual vs Thrust")
+    ax.set_xlabel("Thrust [0-1]")
+    ax.set_ylabel("Corrected Residual [m]")
+    ax.axhline(0, color="k", linewidth=0.5, linestyle="--", alpha=0.3)
+    ax.grid(True, alpha=0.3)
+
+    # Bottom-right: Statistics summary
+    ax = axes[1, 1]
+    ax.axis("off")
+    raw_std = float(np.std(residual))
+    corr_std = float(np.std(corrected_centered))
+    raw_r = _safe_corrcoef(thrust_mag, residual)
+    corr_r = _safe_corrcoef(thrust_mag, corrected_centered)
+    var_reduction = ((1.0 - corr_std**2 / raw_std**2) * 100
+                     if raw_std > 0 else 0)
+
+    lines = [
+        "Compensation Summary",
+        "",
+        f"  Estimated K        = {final_k:.3f} m/unit thrust",
+        f"  SENS_BARO_PCOEF    = {-final_k:+.2f}",
+        "",
+        "  Residual std:",
+        f"    Raw:         {raw_std:.3f} m",
+        f"    Corrected:   {corr_std:.3f} m",
+        f"    Reduction:   {var_reduction:.1f}%",
+        "",
+        "  Thrust correlation |r|:",
+        f"    Raw:         {abs(raw_r):.3f} ({_correlation_quality(raw_r)})",
+        f"    Corrected:   {abs(corr_r):.3f} ({_correlation_quality(corr_r)})",
+    ]
+    ax.text(0.05, 0.95, "\n".join(lines), transform=ax.transAxes,
+            fontsize=11, verticalalignment="top", family="monospace",
+            bbox=dict(boxstyle="round,pad=0.5", facecolor="#f0f0f0",
+                      edgecolor="#cccccc"))
+
+    plt.tight_layout(rect=[0, 0, 1, _LAYOUT_TOP])
+    return fig
+
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _safe_corrcoef(x, y):
+    """Pearson correlation, returning 0 if either input has zero variance."""
+    if len(x) < 2 or np.std(x) < 1e-10 or np.std(y) < 1e-10:
+        return 0.0
+    return float(np.corrcoef(x, y)[0, 1])
+
+
+def _correlation_quality(r):
+    """Return a label for correlation magnitude."""
+    ar = abs(r)
+    if ar > 0.6:
+        return "strong"
+    if ar > 0.3:
+        return "moderate"
+    return "weak"
+
+
+def _print_open_loop_delay(ol):
+    """Print open-loop delay estimate."""
+    print(f"\n--- Open-Loop Delay (feedback-rejected, "
+          f"HP cutoff ~{ol['hp_window_ms']:.0f}ms) ---")
+    peak = ol["peak_lag_s"] * 1000
+    print(f"  Cross-corr peak:  {peak:+.0f}ms (r={ol['peak_r']:.3f})")
+    best = ol["best_lag_s"] * 1000
+    print(f"  Best lag R\u00b2:      {ol['best_lag_r2']:.3f} "
+          f"(lag={best:+.0f}ms)")
+    print(f"  Zero lag R\u00b2:      {ol['zero_lag_r2']:.3f}")
+    delta = ol["best_lag_r2"] - ol["zero_lag_r2"]
+    if delta < 0.01:
+        print(f"  -> No significant delay detected")
+    else:
+        print(f"  -> Physical delay ~{abs(best):.0f}ms "
+              f"(R\u00b2 gain: +{delta:.3f})")
+
+
+def _print_diagnostics(diag):
+    """Print residual diagnostic results to console."""
+    print(f"\n--- Residual Diagnostics ---")
+    print(f"  Linear R\u00b2 (zero lag):    {diag['linear_r2']:.3f}")
+    print(f"  Linear R\u00b2 (best lag):    {diag['best_lag_r2']:.3f}"
+          f"  (lag={diag['best_lag_s']*1000:+.0f}ms)")
+    print(f"  Quadratic R\u00b2 (zero lag): {diag['quad_r2']:.3f}")
+    print(f"  Combined R\u00b2 (lag+quad):  {diag['combined_r2']:.3f}")
+    if "xcorr_peak_lag_s" in diag:
+        print(f"  Cross-corr peak:         {diag['xcorr_peak_lag_s']*1000:+.0f}ms"
+              f" (r={diag['xcorr_peak_value']:.3f})")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze barometer thrust compensation from flight logs")
+    parser.add_argument("ulog_file", help="Path to .ulg flight log")
+    # Default output: logs/<log_name>/ relative to PX4 root (script location)
+    px4_root = os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))))
+    default_log_dir = os.path.join(px4_root, "logs")
+    parser.add_argument("--output-dir", "-o", default=default_log_dir,
+                        help="Output base directory (default: <PX4_ROOT>/logs/)")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.ulog_file):
+        print(f"Error: file not found: {args.ulog_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create per-log output directory: <default_base>/<log_name>/ when using
+    # the default, or use --output-dir directly when explicitly provided.
+    log_name = os.path.splitext(os.path.basename(args.ulog_file))[0]
+
+    if args.output_dir == default_log_dir:
+        output_dir = os.path.join(args.output_dir, log_name)
+    else:
+        output_dir = args.output_dir
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Copy ULG into output dir for co-location
+    ulg_dest = os.path.join(output_dir, os.path.basename(args.ulog_file))
+    if not os.path.exists(ulg_dest):
+        shutil.copy2(args.ulog_file, ulg_dest)
+
+    # Capture console output for summary page
+    _log_buf = io.StringIO()
+    _orig_stdout = sys.stdout
+
+    class _Tee:
+        def __init__(self, *streams):
+            self.streams = streams
+        def write(self, data):
+            for s in self.streams:
+                s.write(data)
+        def flush(self):
+            for s in self.streams:
+                s.flush()
+
+    sys.stdout = _Tee(_orig_stdout, _log_buf)
+
+    # Load log
+    print(f"Loading {args.ulog_file} ...")
+    ulog = ULog(args.ulog_file)
+    duration = (ulog.last_timestamp - ulog.start_timestamp) / 1e6
+    print(f"  Duration: {duration:.1f} s")
+
+    # Print relevant parameters
+    print("\nParameters:")
+    for p in ["EKF2_HGT_REF", "EKF2_BARO_CTRL", "EKF2_BARO_NOISE",
+              "SENS_BARO_PCOEF", "SENS_BAR_AUTOCAL"]:
+        val = get_param(ulog, p)
+        if val is not None:
+            print(f"  {p:24s} = {val}")
+
+    # Detect what data is available
+    existing_pcoef = float(get_param(ulog, 'SENS_BARO_PCOEF', 0.0))
+    is_calibrated = (existing_pcoef != 0.0)
+
+    armed_start, armed_end = detect_armed_period(ulog)
+    hover_start, hover_end = find_hover_segment(armed_start, armed_end)
+    print(f"\nArmed:  {armed_start:.1f}s - {armed_end:.1f}s")
+    print(f"Hover:  {hover_start:.1f}s - {hover_end:.1f}s")
+
+    # Extract data
+    baro = extract_baro(ulog)
+    range_data = extract_range(ulog)
+    thrust_data = extract_thrust(ulog)
+    est_data = extract_estimator(ulog)
+    ekf_z = extract_ekf_z(ulog)
+    ekf_baro_obs = extract_ekf_baro_obs(ulog)
+
+    if baro is None:
+        print("Error: no barometer data (vehicle_air_data) in log",
+              file=sys.stderr)
+        sys.exit(1)
+    if thrust_data is None:
+        print("Error: no thrust data (actuator_motors) in log",
+              file=sys.stderr)
+        sys.exit(1)
+
+    has_range = range_data is not None
+    has_estimator = est_data is not None
+
+    print(f"\n  Baro samples:      {len(baro['time_s'])}")
+    print(f"  Thrust samples:    {len(thrust_data['time_s'])}")
+    print(f"  Range sensor:      {'yes' if has_range else 'no'}")
+    print(f"  Online estimator:  {'yes' if has_estimator else 'no'}")
+    if has_range:
+        print(f"  Range samples:     {len(range_data['time_s'])}")
+    if has_estimator:
+        print(f"  Estimator samples: {len(est_data['time_s'])}")
+
+    figures = []
+
+    # Altitude overview — always first page
+    figures.append(plot_altitude_overview(
+        ekf_baro_obs, ekf_z, range_data, thrust_data, armed_start, armed_end))
+
+    # ----- Online estimator review (always, when available) -----
+    if has_estimator:
+        print("\n--- Online Estimator Review ---")
+
+        # Find convergence point
+        armed_mask = ((est_data["time_s"] >= armed_start)
+                      & (est_data["time_s"] <= armed_end))
+        conv_mask = armed_mask & (est_data["converged"] > 0)
+
+        if conv_mask.any():
+            conv_idx = np.where(conv_mask)[0][0]
+            final_k = float(est_data["k_estimate"][conv_idx])
+            conv_time = float(est_data["time_s"][conv_idx]) - armed_start
+            print(f"  Converged at {conv_time:.0f}s after arm")
+            print(f"  Final K = {final_k:.3f}")
+            print(f"  Implied PCOEF update: {existing_pcoef:.1f} - {final_k:.2f}"
+                  f" = {existing_pcoef - final_k:+.2f}")
+        else:
+            final_k = float(est_data["k_estimate"][armed_mask][-1]) if armed_mask.any() else 0
+            print("  Did NOT converge during this flight")
+            print(f"  Last K = {final_k:.3f}")
+
+        figures.append(plot_estimator_convergence(
+            est_data, armed_start, armed_end, existing_pcoef))
+        figures.append(plot_compensation_effect(
+            est_data, thrust_data, armed_start, armed_end))
+
+    # ----- Range-sensor-based analysis (when range available) -----
+    if has_range:
+        baro_err = compute_baro_error(baro, range_data, armed_start)
+        hov = ((baro_err["time_s"] >= hover_start)
+               & (baro_err["time_s"] <= hover_end))
+
+        if hov.sum() < 20:
+            print("\nWarning: not enough data in hover segment for "
+                  "range-based analysis", file=sys.stderr)
+
+        else:
+            err_hov = baro_err["error"][hov]
+
+            if is_calibrated:
+                # --- VALIDATION MODE ---
+                print(f"\n--- Range-Based Validation ---")
+                print(f"  Compensation was ACTIVE (PCOEF={existing_pcoef:+.1f},"
+                      f")")
+
+                print(f"  Observed error:  mean={np.mean(err_hov):+.3f}m,"
+                      f" std={np.std(err_hov):.3f}m")
+
+                raw_baro_err = reconstruct_raw_error(
+                    baro_err, thrust_data, existing_pcoef)
+                raw_hov = raw_baro_err["error"][hov]
+                print(f"  Reconstructed raw: mean={np.mean(raw_hov):+.3f}m,"
+                      f" std={np.std(raw_hov):.3f}m")
+
+                thrust_interp_mag = np.interp(baro_err["time_s"][hov],
+                              thrust_data["time_s"], thrust_data["thrust"])
+                r_raw = _safe_corrcoef(thrust_interp_mag, raw_hov)
+                r_comp = _safe_corrcoef(thrust_interp_mag, err_hov)
+                print(f"  Thrust |r|: raw={abs(r_raw):.3f} "
+                      f"({_correlation_quality(r_raw)}), "
+                      f"compensated={abs(r_comp):.3f} "
+                      f"({_correlation_quality(r_comp)})")
+
+                calib = calibrate(raw_baro_err, thrust_data,
+                                  hover_start, hover_end)
+                if calib is not None:
+                    # calibrate() ran on reconstructed raw error, so
+                    # recommended_pcoef is the TOTAL value, not a delta.
+                    offline_new = calib['recommended_pcoef']
+                    offline_delta = offline_new - existing_pcoef
+                    print(f"  Re-identified: K={calib['best_K']:.3f},"
+                          f" R\u00b2={calib['best_r2']:.3f}")
+                    print(f"\n  SENS_BARO_PCOEF = {existing_pcoef:+.2f}"
+                          f" + ({offline_delta:+.2f})"
+                          f" = {offline_new:+.2f}")
+
+                    # Cross-validate with online estimator
+                    if has_estimator and conv_mask.any():
+                        # Online K is the residual after existing compensation
+                        online_delta = -final_k
+                        online_total = existing_pcoef + online_delta
+                        print(f"\n--- Cross-Validation ---")
+                        print(f"  Online:  PCOEF = {existing_pcoef:+.2f}"
+                              f" + ({online_delta:+.2f})"
+                              f" = {online_total:+.2f}")
+                        print(f"  Offline: PCOEF = {existing_pcoef:+.2f}"
+                              f" + ({offline_delta:+.2f})"
+                              f" = {offline_new:+.2f}")
+                        pcoef_diff = abs(online_total - offline_new)
+                        print(f"  Agreement: {pcoef_diff:.2f}m"
+                              f" ({'good' if pcoef_diff < 2.0 else 'notable'})")
+
+                    if has_estimator:
+                        figures.append(plot_compensation_comparison(
+                            baro_err, thrust_data, calib, final_k,
+                            armed_start, armed_end,
+                            existing_pcoef))
+                        figures.append(plot_online_vs_offline(
+                            baro_err, thrust_data, calib, final_k,
+                            armed_start, armed_end,
+                            existing_pcoef))
+
+                    # Residual diagnostics on reconstructed raw error
+                    diag = diagnose_residual(raw_baro_err, thrust_data,
+                                            hover_start, hover_end)
+                    if diag is not None:
+                        _print_diagnostics(diag)
+                        figures.append(plot_residual_diagnostics(diag, calib))
+
+                    # Open-loop delay (feedback-rejected)
+                    ol_delay = estimate_open_loop_delay(
+                        raw_baro_err, thrust_data,
+                        hover_start, hover_end)
+                    if ol_delay is not None:
+                        _print_open_loop_delay(ol_delay)
+                        figures.append(plot_open_loop_delay(ol_delay))
+
+            else:
+                # --- CALIBRATION MODE ---
+                print(f"\n--- Range-Based Calibration ---")
+                print(f"  No compensation active")
+                print(f"  Baro error: mean={np.mean(err_hov):+.3f}m,"
+                      f" std={np.std(err_hov):.3f}m")
+
+                thrust_interp = np.interp(
+                    baro_err["time_s"][hov], thrust_data["time_s"],
+                    thrust_data["thrust"])
+                r_thrust = _safe_corrcoef(thrust_interp, err_hov)
+                print(f"  Thrust correlation: r={r_thrust:+.3f}"
+                      f" ({_correlation_quality(r_thrust)})")
+
+                calib = calibrate(baro_err, thrust_data,
+                                  hover_start, hover_end)
+                if calib is not None:
+                    print(f"\n  Identified K  = {calib['best_K']:.3f}")
+                    print(f"  Model R\u00b2     = {calib['best_r2']:.3f}")
+                    print(f"  Residual RMSE = {calib['best_rmse']:.3f}m")
+
+                    new_pcoef = calib['recommended_pcoef']
+                    print(f"\n{'='*50}")
+                    print(f"  RECOMMENDED PARAMETERS")
+                    print(f"{'='*50}")
+                    print(f"  SENS_BARO_PCOEF = {new_pcoef:+.2f}")
+                    print(f"{'='*50}")
+
+                    # Cross-validate with online estimator
+                    if has_estimator and conv_mask.any():
+                        print(f"\n--- Cross-Validation ---")
+                        print(f"  Online:  K={final_k:.3f},"
+                              f" PCOEF={-final_k:+.2f}")
+                        print(f"  Offline: K={calib['best_K']:.3f},"
+                              f" PCOEF={calib['recommended_pcoef']:+.2f}")
+                        k_diff = abs(final_k - calib['best_K'])
+                        print(f"  K agreement: {k_diff:.2f}m"
+                              f" ({'good' if k_diff < 2.0 else 'notable'})")
+
+                    if has_estimator:
+                        figures.append(plot_compensation_comparison(
+                            baro_err, thrust_data, calib, final_k,
+                            armed_start, armed_end))
+                        figures.append(plot_online_vs_offline(
+                            baro_err, thrust_data, calib, final_k,
+                            armed_start, armed_end))
+
+                    # Residual diagnostics
+                    diag = diagnose_residual(baro_err, thrust_data,
+                                            hover_start, hover_end)
+                    if diag is not None:
+                        _print_diagnostics(diag)
+                        figures.append(plot_residual_diagnostics(diag, calib))
+
+                    # Open-loop delay (feedback-rejected)
+                    ol_delay = estimate_open_loop_delay(
+                        baro_err, thrust_data,
+                        hover_start, hover_end)
+                    if ol_delay is not None:
+                        _print_open_loop_delay(ol_delay)
+                        figures.append(plot_open_loop_delay(ol_delay))
+                else:
+                    print("  Calibration failed: insufficient data or "
+                          "thrust variation.")
+
+    elif not has_estimator:
+        print("\nError: no range sensor and no online estimator data.\n"
+              "Need at least one of: distance_sensor or baro_thrust_estimate",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Restore stdout and grab captured text
+    sys.stdout = _orig_stdout
+    summary_text = _log_buf.getvalue()
+
+    # Write PDF with log name in filename
+    if figures:
+        # Add summary page as final page
+        summary_lines = summary_text.strip().split("\n")
+        figures.append(plot_summary_text(summary_lines))
+
+        pdf_path = os.path.join(output_dir, f"{log_name}.pdf")
+
+        with PdfPages(pdf_path) as pdf:
+            for fig in figures:
+                pdf.savefig(fig)
+                plt.close(fig)
+        print(f"\n  Saved: {pdf_path}")
+    else:
+        print("\nNo plots generated.")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/baro_compensation/baro_thrust_calibration.py
+++ b/Tools/baro_compensation/baro_thrust_calibration.py
@@ -164,14 +164,25 @@ def extract_ekf_baro_obs(ulog):
 
 
 def extract_range(ulog):
-    """Extract range sensor distance from distance_sensor."""
+    """Extract range sensor distance from distance_sensor.
+
+    Filters out non-finite distances and samples with signal_quality == 0.
+    """
     start_us = ulog.start_timestamp
     dist = get_topic(ulog, "distance_sensor")
     if dist is None:
         return None
+
+    time_s = us_to_seconds(dist.data["timestamp"], start_us)
+    distance_m = dist.data["current_distance"]
+
+    valid = np.isfinite(time_s) & np.isfinite(distance_m)
+    if "signal_quality" in dist.data.dtype.names:
+        valid &= dist.data["signal_quality"] > 0
+
     return {
-        "time_s": us_to_seconds(dist.data["timestamp"], start_us),
-        "distance_m": dist.data["current_distance"],
+        "time_s": time_s[valid],
+        "distance_m": distance_m[valid],
     }
 
 
@@ -1403,8 +1414,7 @@ def main():
             if is_calibrated:
                 # --- VALIDATION MODE ---
                 print(f"\n--- Range-Based Validation ---")
-                print(f"  Compensation was ACTIVE (PCOEF={existing_pcoef:+.1f},"
-                      f")")
+                print(f"  Compensation was ACTIVE (PCOEF={existing_pcoef:+.1f})")
 
                 print(f"  Observed error:  mean={np.mean(err_hov):+.3f}m,"
                       f" std={np.std(err_hov):.3f}m")

--- a/msg/BaroThrustEstimate.msg
+++ b/msg/BaroThrustEstimate.msg
@@ -1,0 +1,11 @@
+uint64 timestamp                # time since system start (microseconds)
+uint64 timestamp_sample         # time of baro data last used for this estimate
+
+float32 residual                # CF residual: baro minus accel-predicted altitude [m]
+float32 k_estimate              # estimated thrust-to-baro gain [m/unit_thrust]
+float32 k_estimate_var          # variance of K estimate (P[0][0])
+float32 error_var               # RLS prediction error variance
+float32 thrust_std              # standard deviation of recent thrust excitation
+
+bool converged                  # true when all convergence criteria are met
+bool estimation_active          # true when RLS is updating (soft guards not active)

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -47,6 +47,7 @@ set(msg_files
 	Airspeed.msg
 	AirspeedWind.msg
 	AutotuneAttitudeControlStatus.msg
+	BaroThrustEstimate.msg
 	BatteryInfo.msg
 	ButtonEvent.msg
 	CameraCapture.msg

--- a/src/lib/parameters/param_translation.cpp
+++ b/src/lib/parameters/param_translation.cpp
@@ -244,5 +244,15 @@ param_modify_on_import_ret param_modify_on_import(bson_node_t node)
 		}
 	}
 
+	// 2026-03-31: SENS_BAR_AUTOCAL boolean -> bitmask (bit 0: GNSS cal, bit 1: thrust comp)
+	{
+		if (strcmp("SENS_BAR_AUTOCAL", node->name) == 0 && node->type == bson_type_t::BSON_BOOL) {
+			node->i32 = node->b ? 1 : 0;
+			node->type = bson_type_t::BSON_INT32;
+			PX4_INFO("migrating %s from bool to bitmask", node->name);
+			return param_modify_on_import_ret::PARAM_MODIFIED;
+		}
+	}
+
 	return param_modify_on_import_ret::PARAM_NOT_MODIFIED;
 }

--- a/src/modules/baro_thrust_estimator/BaroThrustEstimator.cpp
+++ b/src/modules/baro_thrust_estimator/BaroThrustEstimator.cpp
@@ -303,7 +303,7 @@ void BaroThrustEstimator::publishStatus(hrt_abstime now, float residual, bool es
 	status.error_var = _estimator.errorVar();
 	status.thrust_std = _estimator.thrustStd();
 	status.converged = _estimator.converged();
-	status.estimation_active = estimation_active;
+	status.estimation_active = estimation_active && !_estimator.converged();
 	status.timestamp = hrt_absolute_time();
 
 	_baro_thrust_estimate_pub.publish(status);

--- a/src/modules/baro_thrust_estimator/BaroThrustEstimator.cpp
+++ b/src/modules/baro_thrust_estimator/BaroThrustEstimator.cpp
@@ -1,0 +1,386 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file BaroThrustEstimator.cpp
+ *
+ * Online estimator for barometer thrust compensation parameters.
+ *
+ * Uses a complementary filter (accel-integrated altitude vs baro) to isolate
+ * thrust-induced baro pressure errors. The CF residual (baro - accel_prediction)
+ * captures propwash effects while rejecting real altitude changes and accel drift.
+ * An RLS estimator identifies the gain K using mean motor output from
+ * actuator_motors. Converged parameters are saved on disarm.
+ */
+
+#include "BaroThrustEstimator.hpp"
+
+#include <mathlib/mathlib.h>
+
+using namespace time_literals;
+
+ModuleBase::Descriptor BaroThrustEstimator::desc{task_spawn, custom_command, print_usage};
+
+BaroThrustEstimator::BaroThrustEstimator() :
+	ModuleParams(nullptr),
+	WorkItem(MODULE_NAME, px4::wq_configurations::nav_and_controllers)
+{
+	_estimator.reset();
+	updateParams();
+}
+
+BaroThrustEstimator::~BaroThrustEstimator()
+{
+	perf_free(_cycle_perf);
+}
+
+bool BaroThrustEstimator::init()
+{
+	if (!_vehicle_air_data_sub.registerCallback()) {
+		PX4_ERR("callback registration failed");
+		return false;
+	}
+
+	return true;
+}
+
+void BaroThrustEstimator::updateParams()
+{
+	ModuleParams::updateParams();
+}
+
+void BaroThrustEstimator::Run()
+{
+	if (should_exit()) {
+		_vehicle_air_data_sub.unregisterCallback();
+		exit_and_cleanup(desc);
+		return;
+	}
+
+	perf_begin(_cycle_perf);
+
+	// Handle parameter updates
+	if (_parameter_update_sub.updated()) {
+		parameter_update_s pupdate;
+		_parameter_update_sub.copy(&pupdate);
+		updateParams();
+	}
+
+	// Track arm state for disarm edge detection
+	if (_vehicle_status_sub.updated()) {
+		vehicle_status_s status;
+
+		if (_vehicle_status_sub.copy(&status)) {
+			const bool was_armed = _armed;
+			_armed = (status.arming_state == vehicle_status_s::ARMING_STATE_ARMED);
+
+			if (was_armed != _armed) {
+				if (was_armed && !_armed) {
+					saveParameters();
+				}
+
+				_estimator.reset();
+				_estimation_start_time = 0;
+				_last_update_time = 0;
+				_last_publish_time = 0;
+			}
+		}
+	}
+
+	// Track landed state
+	if (_vehicle_land_detected_sub.updated()) {
+		vehicle_land_detected_s ld;
+
+		if (_vehicle_land_detected_sub.copy(&ld)) {
+			_landed = ld.landed;
+		}
+	}
+
+	// Get baro data (callback trigger)
+	vehicle_air_data_s air_data{};
+
+	if (!_vehicle_air_data_sub.copy(&air_data)) {
+		perf_end(_cycle_perf);
+		return;
+	}
+
+	// Hard guards: no estimation or CF when disarmed/landed
+	if (!_armed || _landed) {
+		perf_end(_cycle_perf);
+		return;
+	}
+
+	// Compute dt
+	const hrt_abstime now = air_data.timestamp_sample;
+
+	if (_last_update_time == 0) {
+		_last_update_time = now;
+		_estimation_start_time = now;
+		perf_end(_cycle_perf);
+		return;
+	}
+
+	const float dt = math::constrain(static_cast<float>(now - _last_update_time) * 1e-6f, 0.001f, 0.5f);
+	_last_update_time = now;
+
+	// Validate baro
+	if (!PX4_ISFINITE(air_data.baro_alt_meter)) {
+		perf_end(_cycle_perf);
+		return;
+	}
+
+	// Get acceleration in body frame
+	vehicle_acceleration_s accel{};
+
+	if (!_vehicle_acceleration_sub.copy(&accel)
+	    || hrt_elapsed_time(&accel.timestamp) > 100_ms
+	    || !PX4_ISFINITE(accel.xyz[0]) || !PX4_ISFINITE(accel.xyz[1]) || !PX4_ISFINITE(accel.xyz[2])) {
+		perf_end(_cycle_perf);
+		return;
+	}
+
+	// Get attitude quaternion
+	vehicle_attitude_s att{};
+
+	if (!_vehicle_attitude_sub.copy(&att)
+	    || hrt_elapsed_time(&att.timestamp) > 100_ms
+	    || !PX4_ISFINITE(att.q[0])) {
+		perf_end(_cycle_perf);
+		return;
+	}
+
+	// Compute upward linear acceleration and CF residual
+	const float accel_up = BaroThrustCfRls::computeAccelUp(
+					matrix::Vector3f{accel.xyz}, matrix::Quatf{att.q});
+
+	const float residual = _estimator.updateCf(air_data.baro_alt_meter, accel_up, dt);
+
+	if (!PX4_ISFINITE(residual)) {
+		perf_end(_cycle_perf);
+		return;
+	}
+
+	// Soft guards: skip RLS update but keep CF current
+	bool estimation_active = true;
+
+	vehicle_local_position_s local_pos{};
+
+	if (_vehicle_local_position_sub.copy(&local_pos)) {
+		if (local_pos.v_z_valid && fabsf(local_pos.vz) > MAX_VZ) {
+			estimation_active = false;
+		}
+
+		if (local_pos.v_xy_valid
+		    && (local_pos.vx * local_pos.vx + local_pos.vy * local_pos.vy) > MAX_VXY * MAX_VXY) {
+			estimation_active = false;
+		}
+	}
+
+	// Get vertical thrust setpoint — uses latest sample rather than time-matched
+	// (unlike thrustCompensation). Fine for a statistical estimator; timing jitter is noise.
+	float thrust = 0.f;
+
+	vehicle_thrust_setpoint_s thrust_sp{};
+
+	if (_vehicle_thrust_setpoint_sub.copy(&thrust_sp)
+	    && hrt_elapsed_time(&thrust_sp.timestamp) < 500_ms
+	    && PX4_ISFINITE(thrust_sp.xyz[2])) {
+		thrust = fabsf(thrust_sp.xyz[2]);
+
+	} else {
+		estimation_active = false;
+	}
+
+	// Once converged, freeze RLS — the estimate is good and continued
+	// updates during descent/landing would corrupt it with ground effect.
+	// Note: when updateEstimator() stops being called, all internal
+	// tracking state (thrust variance, K smoothed, RLS covariance) freezes,
+	// so the convergence criteria checked by checkConvergence() remain
+	// stable and converged() cannot flicker back to false.
+	if (estimation_active && !_estimator.converged() && !_estimator.convergedLocked()) {
+		_estimator.updateEstimator(residual, thrust, dt);
+	}
+
+	// Convergence checking runs independently of soft guards so the hold
+	// timer keeps ticking during descent. With RLS frozen the checked
+	// values (variance, error, stability) remain stable.
+	if (!_estimator.convergedLocked()) {
+		const float elapsed_s = static_cast<float>(now - _estimation_start_time) * 1e-6f;
+		_estimator.checkConvergence(elapsed_s, dt);
+
+		if (_estimator.convergedLocked()) {
+			PX4_INFO("convergence locked (K=%.2f)", (double)_estimator.kEstimate());
+		}
+	}
+
+	if (now - _last_publish_time > 200_ms) {
+		publishStatus(now, residual, estimation_active);
+		_last_publish_time = now;
+	}
+
+	perf_end(_cycle_perf);
+}
+
+void BaroThrustEstimator::saveParameters()
+{
+	if (!_estimator.convergedLocked()) {
+		PX4_INFO("baro thrust estimator did not converge (K=%.2f, var=%.1f, err=%.2f, thr_std=%.3f)",
+			 (double)_estimator.kEstimate(),
+			 (double)_estimator.kEstimateVar(),
+			 (double)_estimator.errorVar(),
+			 (double)_estimator.thrustStd());
+		return;
+	}
+
+	const float K_est = _estimator.kEstimate();
+
+	// Only update if the remaining error is significant
+	if (fabsf(K_est) < MIN_K_UPDATE_THRESHOLD) {
+		PX4_INFO("K_est=%.2f below threshold, calibration adequate", (double)K_est);
+		return;
+	}
+
+	// K_est is the residual gain the estimator sees *after* existing compensation,
+	// so the corrected PCOEF shifts by -K_est to cancel it out.
+	const float pcoef_new = _param_sens_baro_pcoef.get() - K_est;
+
+	if (!PX4_ISFINITE(pcoef_new)) {
+		PX4_WARN("non-finite result, skipping save");
+		return;
+	}
+
+	if (fabsf(pcoef_new) > PCOEF_MAX) {
+		PX4_WARN("result out of range (pcoef=%.1f)", (double)pcoef_new);
+		return;
+	}
+
+	PX4_INFO("saving SENS_BARO_PCOEF=%.1f (K_est=%.2f, prev_pcoef=%.1f)",
+		 (double)pcoef_new, (double)K_est,
+		 (double)_param_sens_baro_pcoef.get());
+
+	_param_sens_baro_pcoef.set(pcoef_new);
+	_param_sens_baro_pcoef.commit_no_notification();
+}
+
+void BaroThrustEstimator::publishStatus(hrt_abstime now, float residual, bool estimation_active)
+{
+	baro_thrust_estimate_s status{};
+	status.timestamp_sample = now;
+	status.residual = residual;
+	status.k_estimate = _estimator.kEstimate();
+	status.k_estimate_var = _estimator.kEstimateVar();
+	status.error_var = _estimator.errorVar();
+	status.thrust_std = _estimator.thrustStd();
+	status.converged = _estimator.converged();
+	status.estimation_active = estimation_active;
+	status.timestamp = hrt_absolute_time();
+
+	_baro_thrust_estimate_pub.publish(status);
+}
+
+// ---------------------------------------------------------------------------
+// Module boilerplate
+// ---------------------------------------------------------------------------
+
+int BaroThrustEstimator::task_spawn(int argc, char *argv[])
+{
+	BaroThrustEstimator *instance = new BaroThrustEstimator();
+
+	if (instance) {
+		desc.object.store(instance);
+		desc.task_id = task_id_is_work_queue;
+
+		if (instance->init()) {
+			return PX4_OK;
+		}
+
+	} else {
+		PX4_ERR("alloc failed");
+	}
+
+	delete instance;
+	desc.object.store(nullptr);
+	desc.task_id = -1;
+
+	return PX4_ERROR;
+}
+
+int BaroThrustEstimator::custom_command(int argc, char *argv[])
+{
+	return print_usage("unknown command");
+}
+
+int BaroThrustEstimator::print_status()
+{
+	PX4_INFO("converged: %s", _estimator.converged() ? "yes" : "no");
+	PX4_INFO("K_est: %.3f  K_var: %.4f  error_var: %.4f",
+		 (double)_estimator.kEstimate(), (double)_estimator.kEstimateVar(),
+		 (double)_estimator.errorVar());
+	PX4_INFO("thrust std: %.4f", (double)_estimator.thrustStd());
+	PX4_INFO("current SENS_BARO_PCOEF: %.1f", (double)_param_sens_baro_pcoef.get());
+
+	perf_print_counter(_cycle_perf);
+	return 0;
+}
+
+int BaroThrustEstimator::print_usage(const char *reason)
+{
+	if (reason) {
+		PX4_WARN("%s\n", reason);
+	}
+
+	PRINT_MODULE_DESCRIPTION(
+		R"DESCR_STR(
+### Description
+
+Online estimator for barometer thrust compensation (SENS_BARO_PCOEF).
+
+Uses an accel-baro complementary filter to isolate thrust-induced baro pressure errors.
+The CF residual captures propwash effects while rejecting real altitude changes and
+accelerometer drift. An RLS estimator identifies the thrust-to-baro gain K using mean
+motor output from actuator_motors (which includes physical spin-up delay).
+Converged parameters are saved on disarm and refined over subsequent flights.
+
+)DESCR_STR");
+
+	PRINT_MODULE_USAGE_NAME("baro_thrust_estimator", "estimator");
+	PRINT_MODULE_USAGE_COMMAND("start");
+	PRINT_MODULE_USAGE_DEFAULT_COMMANDS();
+
+	return 0;
+}
+
+extern "C" __EXPORT int baro_thrust_estimator_main(int argc, char *argv[])
+{
+	return ModuleBase::main(BaroThrustEstimator::desc, argc, argv);
+}

--- a/src/modules/baro_thrust_estimator/BaroThrustEstimator.cpp
+++ b/src/modules/baro_thrust_estimator/BaroThrustEstimator.cpp
@@ -39,8 +39,9 @@
  * Uses a complementary filter (accel-integrated altitude vs baro) to isolate
  * thrust-induced baro pressure errors. The CF residual (baro - accel_prediction)
  * captures propwash effects while rejecting real altitude changes and accel drift.
- * An RLS estimator identifies the gain K using mean motor output from
- * actuator_motors. Converged parameters are saved on disarm.
+ * An RLS estimator identifies the gain K using the commanded collective thrust
+ * magnitude from vehicle_thrust_setpoint (|xyz[2]|). Converged parameters are
+ * saved on disarm.
  */
 
 #include "BaroThrustEstimator.hpp"
@@ -367,8 +368,8 @@ Online estimator for barometer thrust compensation (SENS_BARO_PCOEF).
 
 Uses an accel-baro complementary filter to isolate thrust-induced baro pressure errors.
 The CF residual captures propwash effects while rejecting real altitude changes and
-accelerometer drift. An RLS estimator identifies the thrust-to-baro gain K using mean
-motor output from actuator_motors (which includes physical spin-up delay).
+accelerometer drift. An RLS estimator identifies the thrust-to-baro gain K using the
+commanded collective thrust magnitude from vehicle_thrust_setpoint (|xyz[2]|).
 Converged parameters are saved on disarm and refined over subsequent flights.
 
 )DESCR_STR");

--- a/src/modules/baro_thrust_estimator/BaroThrustEstimator.hpp
+++ b/src/modules/baro_thrust_estimator/BaroThrustEstimator.hpp
@@ -1,0 +1,122 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file BaroThrustEstimator.hpp
+ *
+ * Online estimator for barometer thrust compensation parameters.
+ * Module wrapper around BaroThrustCfRls — handles uORB I/O,
+ * parameter persistence, and lifecycle.
+ */
+
+#pragma once
+
+#include "baro_thrust_cf_rls.hpp"
+
+#include <lib/perf/perf_counter.h>
+#include <px4_platform_common/defines.h>
+#include <px4_platform_common/log.h>
+#include <px4_platform_common/module.h>
+#include <px4_platform_common/module_params.h>
+#include <px4_platform_common/px4_work_queue/WorkItem.hpp>
+#include <uORB/Publication.hpp>
+#include <uORB/Subscription.hpp>
+#include <uORB/SubscriptionCallback.hpp>
+#include <uORB/SubscriptionInterval.hpp>
+#include <uORB/topics/baro_thrust_estimate.h>
+#include <uORB/topics/parameter_update.h>
+#include <uORB/topics/vehicle_acceleration.h>
+#include <uORB/topics/vehicle_air_data.h>
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_land_detected.h>
+#include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/vehicle_thrust_setpoint.h>
+
+using namespace time_literals;
+
+class BaroThrustEstimator : public ModuleBase, public ModuleParams,
+	public px4::WorkItem
+{
+public:
+	static Descriptor desc;
+
+	BaroThrustEstimator();
+	~BaroThrustEstimator() override;
+
+	static int task_spawn(int argc, char *argv[]);
+	static int custom_command(int argc, char *argv[]);
+	static int print_usage(const char *reason = nullptr);
+
+	bool init();
+	int print_status() override;
+
+private:
+	static constexpr float MAX_VZ = 2.f;
+	static constexpr float MAX_VXY = 5.f;
+	static constexpr float PCOEF_MAX = 30.f;
+	static constexpr float MIN_K_UPDATE_THRESHOLD = 0.1f;
+
+	void Run() override;
+	void updateParams() override;
+	void saveParameters();
+	void publishStatus(hrt_abstime now, float residual, bool estimation_active);
+
+	BaroThrustCfRls _estimator{};
+
+	// Subscriptions
+	uORB::SubscriptionCallbackWorkItem _vehicle_air_data_sub{this, ORB_ID(vehicle_air_data)};
+	uORB::SubscriptionInterval _parameter_update_sub{ORB_ID(parameter_update), 1_s};
+	uORB::Subscription _vehicle_acceleration_sub{ORB_ID(vehicle_acceleration)};
+	uORB::Subscription _vehicle_attitude_sub{ORB_ID(vehicle_attitude)};
+	uORB::Subscription _vehicle_thrust_setpoint_sub{ORB_ID(vehicle_thrust_setpoint)};
+	uORB::Subscription _vehicle_status_sub{ORB_ID(vehicle_status)};
+	uORB::Subscription _vehicle_land_detected_sub{ORB_ID(vehicle_land_detected)};
+	uORB::Subscription _vehicle_local_position_sub{ORB_ID(vehicle_local_position)};
+
+	// Publication
+	uORB::Publication<baro_thrust_estimate_s> _baro_thrust_estimate_pub{ORB_ID(baro_thrust_estimate)};
+
+	// State
+	bool _armed{false};
+	bool _landed{true};
+	hrt_abstime _estimation_start_time{0};
+	hrt_abstime _last_update_time{0};
+	hrt_abstime _last_publish_time{0};
+
+	perf_counter_t _cycle_perf{perf_alloc(PC_ELAPSED, MODULE_NAME": cycle")};
+
+	DEFINE_PARAMETERS(
+		(ParamFloat<px4::params::SENS_BARO_PCOEF>) _param_sens_baro_pcoef
+	)
+};

--- a/src/modules/baro_thrust_estimator/CMakeLists.txt
+++ b/src/modules/baro_thrust_estimator/CMakeLists.txt
@@ -1,0 +1,53 @@
+############################################################################
+#
+#   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+
+px4_add_library(baro_thrust_cf_rls
+	baro_thrust_cf_rls.cpp
+	baro_thrust_cf_rls.hpp
+)
+
+px4_add_module(
+	MODULE modules__baro_thrust_estimator
+	MAIN baro_thrust_estimator
+	COMPILE_FLAGS
+		${MAX_CUSTOM_OPT_LEVEL}
+	SRCS
+		BaroThrustEstimator.cpp
+		BaroThrustEstimator.hpp
+	DEPENDS
+		baro_thrust_cf_rls
+		mathlib
+		px4_work_queue
+)
+
+px4_add_unit_gtest(SRC baro_thrust_cf_rls_test.cpp LINKLIBS baro_thrust_cf_rls)

--- a/src/modules/baro_thrust_estimator/Kconfig
+++ b/src/modules/baro_thrust_estimator/Kconfig
@@ -1,0 +1,12 @@
+menuconfig MODULES_BARO_THRUST_ESTIMATOR
+	bool "baro_thrust_estimator"
+	default y
+	---help---
+		Enable support for baro_thrust_estimator
+
+menuconfig USER_BARO_THRUST_ESTIMATOR
+	bool "baro_thrust_estimator running as userspace module"
+	default y
+	depends on BOARD_PROTECTED && MODULES_BARO_THRUST_ESTIMATOR
+	---help---
+		Put baro_thrust_estimator in userspace memory

--- a/src/modules/baro_thrust_estimator/baro_thrust_cf_rls.cpp
+++ b/src/modules/baro_thrust_estimator/baro_thrust_cf_rls.cpp
@@ -1,0 +1,223 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include "baro_thrust_cf_rls.hpp"
+
+void BaroThrustCfRls::reset()
+{
+	_rls.reset(RLS_P_INIT);
+
+	_cf_alt = 0.f;
+	_cf_vel = 0.f;
+	_cf_initialized = false;
+
+	_converged = false;
+	_converged_locked = false;
+	_converged_elapsed_s = 0.f;
+	_k_stable_elapsed_s = 0.f;
+	_k_est_smoothed.reset(0.f);
+	_thrust_mean.reset(0.f);
+	_thrust_var.reset(0.f);
+}
+
+float BaroThrustCfRls::computeAccelUp(const matrix::Vector3f &accel_body,
+		const matrix::Quatf &attitude)
+{
+	// Rotate body-frame specific force to NED, extract Z component
+	const float specific_force_ned_z = (attitude.rotateVector(accel_body))(2);
+
+	// Convert to altitude-up coordinate acceleration
+	// specific_force = a_inertial - g_vec, so a_inertial_z = specific_force_z + g
+	// altitude = -NED_z, so accel_up = -(specific_force_z + g)
+	return -(specific_force_ned_z + CONSTANTS_ONE_G);
+}
+
+float BaroThrustCfRls::updateCf(float baro_alt, float accel_up, float dt)
+{
+	if (!_cf_initialized) {
+		_cf_alt = baro_alt;
+		_cf_vel = 0.f;
+		_cf_initialized = true;
+		return 0.f;
+	}
+
+	// Predict altitude from accel integration
+	const float alt_pred = _cf_alt + _cf_vel * dt + 0.5f * accel_up * dt * dt;
+	const float vel_pred = _cf_vel + accel_up * dt;
+
+	// CF residual: what the baro says minus what accel predicts
+	const float residual = baro_alt - alt_pred;
+
+	// Correct CF state with baro at low bandwidth to prevent accel drift
+	// 2nd-order critically damped: K1 = 2*omega, K2 = omega^2
+	constexpr float omega = 2.f * 3.14159265f * CF_BANDWIDTH_HZ;
+	constexpr float K1 = 2.f * omega;
+	constexpr float K2 = omega * omega;
+
+	_cf_alt = alt_pred + K1 * dt * residual;
+	_cf_vel = vel_pred + K2 * dt * residual;
+
+	if (!std::isfinite(_cf_alt) || !std::isfinite(_cf_vel)) {
+		_cf_alt = baro_alt;
+		_cf_vel = 0.f;
+		return 0.f;
+	}
+
+	return residual;
+}
+
+void BaroThrustCfRls::updateEstimator(float residual, float thrust, float dt)
+{
+	_rls.update(residual, thrust, dt, RLS_LAMBDA);
+
+	// Track thrust excitation (compute deviation before updating mean
+	// so the current sample doesn't bias the mean used for deviation)
+	_thrust_mean.setParameters(dt, 2.f);
+	const float thrust_dev = thrust - _thrust_mean.getState();
+	_thrust_mean.update(thrust);
+	_thrust_var.setParameters(dt, 2.f);
+	_thrust_var.update(thrust_dev * thrust_dev);
+
+	// Track K stability
+	_k_est_smoothed.setParameters(dt, 5.f);
+	_k_est_smoothed.update(_rls.theta[0]);
+}
+
+void BaroThrustCfRls::checkConvergence(float elapsed_since_start_s, float dt)
+{
+	if (_converged_locked) {
+		return;
+	}
+
+	const bool variance_ok = _rls.P[0][0] < CONVERGENCE_VAR_THR;
+	const bool excitation_ok = fmaxf(_thrust_var.getState(), 0.f) > (MIN_THRUST_EXCITATION * MIN_THRUST_EXCITATION);
+
+	// Dual-path error check: absolute threshold works for refinement flights
+	// (PCOEF already set), relative threshold allows first calibration where
+	// the uncompensated CF residual is noisy but the model explains most of it.
+	const float K = _rls.theta[0];
+	const float explained_var = K * K * fmaxf(_thrust_var.getState(), 0.f);
+	const float total_var = explained_var + _rls.error_var;
+	const bool error_ok = _rls.error_var < CONVERGENCE_ERR_THR
+			      || (total_var > 1.f
+				  && _rls.error_var / total_var < CONVERGENCE_ERR_REL_THR
+				  && _rls.error_var < CONVERGENCE_ERR_MAX_THR);
+	const bool time_ok = elapsed_since_start_s > MIN_ESTIMATION_TIME_S;
+
+	const float k_current = _k_est_smoothed.getState();
+	const float k_best = _rls.theta[0];
+
+	if (fabsf(k_current - k_best) > K_STABILITY_DIFF_THR) {
+		_k_stable_elapsed_s = 0.f;
+
+	} else {
+		_k_stable_elapsed_s += dt;
+	}
+
+	const bool stability_ok = _k_stable_elapsed_s > K_STABILITY_TIME_S;
+
+	_converged = variance_ok && error_ok && excitation_ok && time_ok && stability_ok;
+
+	// Once converged, keep accumulating hold time even if excitation
+	// momentarily dips — the estimate quality checks (variance, error,
+	// stability) are sufficient to guard the hold period.
+	const bool hold_ok = variance_ok && error_ok && time_ok && stability_ok;
+
+	if (_converged || (_converged_elapsed_s > 0.f && hold_ok)) {
+		_converged_elapsed_s += dt;
+
+		if (_converged_elapsed_s > CONVERGENCE_HOLD_TIME_S) {
+			_converged_locked = true;
+		}
+
+	} else {
+		_converged_elapsed_s = 0.f;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RlsEstimator
+// ---------------------------------------------------------------------------
+
+void BaroThrustCfRls::RlsEstimator::reset(float p_init)
+{
+	theta[0] = 0.f;
+	theta[1] = 0.f;
+	P[0][0] = p_init;
+	P[0][1] = 0.f;
+	P[1][0] = 0.f;
+	P[1][1] = p_init;
+	error_var = ERROR_VAR_INIT;
+}
+
+void BaroThrustCfRls::RlsEstimator::update(float residual, float thrust, float dt, float lambda)
+{
+	const float phi[2] = {thrust, 1.f};
+	const float e = residual - (theta[0] * phi[0] + theta[1] * phi[1]);
+
+	const float Pphi[2] = {
+		P[0][0] * phi[0] + P[0][1] * phi[1],
+		P[1][0] * phi[0] + P[1][1] * phi[1]
+	};
+
+	const float phiPphi = phi[0] * Pphi[0] + phi[1] * Pphi[1];
+	const float denom = lambda + phiPphi;
+
+	if (fabsf(denom) < 1e-10f) {
+		return;
+	}
+
+	const float inv_denom = 1.f / denom;
+
+	theta[0] += Pphi[0] * inv_denom * e;
+	theta[1] += Pphi[1] * inv_denom * e;
+
+	const float inv_lambda = 1.f / lambda;
+
+	for (int i = 0; i < 2; i++) {
+		for (int j = 0; j < 2; j++) {
+			P[i][j] = (P[i][j] - Pphi[i] * Pphi[j] * inv_denom) * inv_lambda;
+		}
+	}
+
+	constexpr float alpha_err = 0.01f;
+	error_var = (1.f - alpha_err) * error_var + alpha_err * e * e;
+
+	// Guard against numerical instability
+	if (!std::isfinite(theta[0]) || !std::isfinite(theta[1])
+	    || !std::isfinite(P[0][0]) || !std::isfinite(P[0][1])
+	    || !std::isfinite(P[1][0]) || !std::isfinite(P[1][1])
+	    || !std::isfinite(error_var)) {
+		reset(RLS_P_INIT);
+	}
+}

--- a/src/modules/baro_thrust_estimator/baro_thrust_cf_rls.hpp
+++ b/src/modules/baro_thrust_estimator/baro_thrust_cf_rls.hpp
@@ -1,0 +1,165 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file baro_thrust_cf_rls.hpp
+ *
+ * Complementary Filter + Recursive Least Squares (CF+RLS) estimator
+ * for barometer thrust compensation.  Pure math — no uORB, no PX4
+ * module infrastructure.
+ *
+ * Problem: propwash creates a static pressure error at the baro sensor
+ * proportional to motor output.  We want to identify the gain K in:
+ *
+ *     baro_error = K * mean_motor_output + bias
+ *
+ * But we can't directly observe baro_error in flight — the vehicle is
+ * actually moving, so baro altitude changes for real reasons too.
+ *
+ * Solution — two stages:
+ *
+ * 1. Complementary Filter (CF) — isolate the baro error signal.
+ *    Fuses barometer altitude with double-integrated accelerometer to
+ *    produce an altitude estimate.  The CF uses a very low crossover
+ *    frequency (0.05 Hz), trusting the accelerometer for fast changes
+ *    and the baro for DC.  The residual (baro minus CF prediction)
+ *    contains the thrust-correlated pressure error plus noise, with
+ *    real vehicle motion removed.
+ *
+ * 2. Recursive Least Squares (RLS) — identify K from the residual.
+ *    Fits the linear model: residual = K * thrust + bias, updating
+ *    the estimate with each new sample.  RLS is chosen over batch
+ *    least-squares because it runs online with O(1) memory, adapts
+ *    to changing conditions, and provides a covariance estimate (P)
+ *    used for convergence detection.  The forgetting factor (lambda)
+ *    down-weights old data to track slow parameter drift.
+ *
+ * Convergence requires: low parameter variance (P[0][0]), acceptable
+ * prediction error (absolute OR relative to explained variance),
+ * sufficient thrust excitation, stable K estimate for 10s, and a 10s
+ * hold period.  The relative error path allows first-flight calibration
+ * (PCOEF=0) where absolute residual is high but the model explains
+ * most of the variance.  Once locked, K is saved to SENS_BARO_PCOEF
+ * on disarm.
+ */
+
+#pragma once
+
+#include <lib/mathlib/math/filter/AlphaFilter.hpp>
+#include <matrix/math.hpp>
+#include <geo/geo.h>
+
+#include <cmath>
+#include <float.h>
+
+class BaroThrustCfRls {
+public:
+	// --- RLS tuning ---
+	static constexpr float RLS_LAMBDA = 0.998f;     ///< forgetting factor (1.0 = never forget, lower = adapt faster)
+	static constexpr float RLS_P_INIT = 100.f;      ///< initial covariance diagonal (high = uncertain, learns fast)
+
+	// --- Convergence criteria ---
+	static constexpr float CONVERGENCE_VAR_THR = 3.f;       ///< max K variance (P[0][0]) to consider converged
+	static constexpr float CONVERGENCE_ERR_THR = 0.5f;      ///< max prediction error variance (absolute) [m^2]
+	static constexpr float CONVERGENCE_ERR_REL_THR = 0.4f;  ///< max error/total variance ratio (model explains >60%)
+	static constexpr float CONVERGENCE_ERR_MAX_THR = 4.0f;   ///< absolute error cap for relative path [m^2]
+	static constexpr float MIN_THRUST_EXCITATION = 0.05f;    ///< min thrust std dev to trust the estimate
+	static constexpr float MIN_ESTIMATION_TIME_S = 30.f;     ///< min flight time before convergence allowed
+	static constexpr float K_STABILITY_TIME_S = 10.f;        ///< K must be stable within threshold for this long
+	static constexpr float CONVERGENCE_HOLD_TIME_S = 10.f;   ///< must stay converged this long before locking
+	static constexpr float K_STABILITY_DIFF_THR = 0.5f;      ///< max |K_smoothed - K_raw| for stability [m]
+
+	// --- Complementary filter ---
+	static constexpr float CF_BANDWIDTH_HZ = 0.05f; ///< crossover frequency — below this, trust baro; above, trust accel
+	static constexpr float ERROR_VAR_INIT = 10.f;   ///< initial prediction error variance
+
+	/**
+	 * 2-state RLS estimator: fits residual = theta[0]*thrust + theta[1]
+	 * where theta[0] = K (the gain we want) and theta[1] = bias.
+	 * P is the 2x2 parameter covariance matrix.
+	 */
+	struct RlsEstimator {
+		float theta[2]{};       ///< [K, bias] parameter estimates
+		float P[2][2]{};        ///< 2x2 parameter covariance
+		float error_var{ERROR_VAR_INIT}; ///< exponentially-weighted prediction error variance
+
+		void reset(float p_init);
+		void update(float residual, float thrust, float dt, float lambda);
+	};
+
+	void reset();
+
+	/**
+	 * Convert body-frame specific force (including gravity, FRD) to
+	 * altitude-up linear acceleration.
+	 */
+	static float computeAccelUp(const matrix::Vector3f &accel_body, const matrix::Quatf &attitude);
+
+	/**
+	 * Update complementary filter and return residual (baro - accel prediction).
+	 */
+	float updateCf(float baro_alt, float accel_up, float dt);
+
+	/**
+	 * Update the RLS estimator with the CF residual and motor thrust.
+	 */
+	void updateEstimator(float residual, float thrust, float dt);
+
+	void checkConvergence(float elapsed_since_start_s, float dt);
+
+	bool converged() const { return _converged; }
+	bool convergedLocked() const { return _converged_locked; }
+	float kEstimate() const { return _rls.theta[0]; }
+	float kEstimateVar() const { return _rls.P[0][0]; }
+	float errorVar() const { return _rls.error_var; }
+	float thrustStd() const { return sqrtf(fmaxf(_thrust_var.getState(), 0.f)); }
+
+private:
+	RlsEstimator _rls{};
+
+	// CF state: 2nd-order (position + velocity) integrator corrected by baro
+	float _cf_alt{0.f};             ///< CF altitude estimate [m]
+	float _cf_vel{0.f};             ///< CF vertical velocity estimate [m/s]
+	bool _cf_initialized{false};
+
+	// Convergence tracking
+	AlphaFilter<float> _k_est_smoothed{};  ///< low-pass filtered K for stability check
+	float _k_stable_elapsed_s{0.f};        ///< time K has been within stability threshold
+	bool _converged{false};                ///< all convergence criteria currently met
+	bool _converged_locked{false};         ///< converged and held long enough — ready to save
+	float _converged_elapsed_s{0.f};       ///< accumulated hold time while converged
+
+	// Thrust excitation tracking (need variation in thrust to observe K)
+	AlphaFilter<float> _thrust_mean{};     ///< low-pass mean thrust
+	AlphaFilter<float> _thrust_var{};      ///< low-pass thrust variance
+};

--- a/src/modules/baro_thrust_estimator/baro_thrust_cf_rls_test.cpp
+++ b/src/modules/baro_thrust_estimator/baro_thrust_cf_rls_test.cpp
@@ -1,0 +1,236 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Test code for BaroThrustCfRls
+ * Run: make tests TESTFILTER=baro_thrust_cf_rls
+ */
+
+#include <gtest/gtest.h>
+#include <matrix/matrix/math.hpp>
+#include <random>
+#include <cmath>
+
+#include "baro_thrust_cf_rls.hpp"
+
+using namespace matrix;
+
+class BaroThrustCfRlsTest : public ::testing::Test
+{
+protected:
+	BaroThrustCfRls _estimator{};
+	static constexpr float _dt = 0.02f; // 50 Hz
+
+	std::default_random_engine _rng{42};
+	std::normal_distribution<float> _normal{0.f, 1.f};
+};
+
+// ---------------------------------------------------------------------------
+// computeAccelUp — gravity handling
+// ---------------------------------------------------------------------------
+
+TEST_F(BaroThrustCfRlsTest, AccelUpAtRestLevel)
+{
+	// At rest, level: specific force in FRD body = {0, 0, -g}
+	const Vector3f accel_body{0.f, 0.f, -CONSTANTS_ONE_G};
+	const Quatf identity{};
+
+	const float accel_up = BaroThrustCfRls::computeAccelUp(accel_body, identity);
+
+	EXPECT_NEAR(accel_up, 0.f, 1e-4f);
+}
+
+TEST_F(BaroThrustCfRlsTest, AccelUpAscending)
+{
+	const float a_up_true = 2.f;
+	const Vector3f accel_body{0.f, 0.f, -(CONSTANTS_ONE_G + a_up_true)};
+	const Quatf identity{};
+
+	const float accel_up = BaroThrustCfRls::computeAccelUp(accel_body, identity);
+
+	EXPECT_NEAR(accel_up, a_up_true, 1e-4f);
+}
+
+TEST_F(BaroThrustCfRlsTest, AccelUpTilted45Hover)
+{
+	const float theta = 45.f * 3.14159265f / 180.f;
+	const Vector3f accel_body{CONSTANTS_ONE_G *sinf(theta), 0.f, -CONSTANTS_ONE_G *cosf(theta)};
+	const Quatf attitude{Eulerf{0.f, theta, 0.f}};
+
+	const float accel_up = BaroThrustCfRls::computeAccelUp(accel_body, attitude);
+
+	EXPECT_NEAR(accel_up, 0.f, 1e-3f);
+}
+
+// ---------------------------------------------------------------------------
+// CF residual
+// ---------------------------------------------------------------------------
+
+TEST_F(BaroThrustCfRlsTest, CfResidualConstantAltitude)
+{
+	_estimator.reset();
+
+	const float baro_alt = 100.f;
+	const float accel_up = 0.f;
+	float residual = 0.f;
+
+	for (int i = 0; i < 500; i++) { // 10 seconds
+		residual = _estimator.updateCf(baro_alt, accel_up, _dt);
+	}
+
+	EXPECT_NEAR(residual, 0.f, 1e-3f);
+}
+
+TEST_F(BaroThrustCfRlsTest, CfResidualCapturesPropwash)
+{
+	_estimator.reset();
+
+	const float true_alt = 100.f;
+
+	// Settle CF
+	for (int i = 0; i < 500; i++) {
+		_estimator.updateCf(true_alt, 0.f, _dt);
+	}
+
+	// Apply a +3 m propwash error to baro
+	const float propwash_error = 3.f;
+	float residual = _estimator.updateCf(true_alt + propwash_error, 0.f, _dt);
+
+	EXPECT_NEAR(residual, propwash_error, 0.5f);
+}
+
+// ---------------------------------------------------------------------------
+// RLS convergence
+// ---------------------------------------------------------------------------
+
+TEST_F(BaroThrustCfRlsTest, RlsConvergenceNoiseless)
+{
+	// Feed residual = K_true * thrust + bias, verify K estimate converges.
+	_estimator.reset();
+
+	const float K_true = -5.f;
+	const float bias_true = 0.3f;
+
+	for (float t = 0.f; t < 30.f; t += _dt) {
+		const float thrust = 0.5f + 0.15f * sinf(2.f * 3.14159f * t / 5.f);
+		const float residual = K_true * thrust + bias_true;
+		_estimator.updateEstimator(residual, thrust, _dt);
+	}
+
+	EXPECT_NEAR(_estimator.kEstimate(), K_true, 0.1f);
+}
+
+TEST_F(BaroThrustCfRlsTest, RlsConvergenceWithNoise)
+{
+	_estimator.reset();
+
+	const float K_true = -3.f;
+	const float bias_true = 0.5f;
+	const float noise_std = 0.3f;
+
+	for (float t = 0.f; t < 60.f; t += _dt) {
+		const float thrust = 0.5f + 0.15f * sinf(2.f * 3.14159f * t / 5.f);
+		const float residual = K_true * thrust + bias_true + noise_std * _normal(_rng);
+		_estimator.updateEstimator(residual, thrust, _dt);
+	}
+
+	EXPECT_NEAR(_estimator.kEstimate(), K_true, 0.5f);
+}
+
+// ---------------------------------------------------------------------------
+// Reset
+// ---------------------------------------------------------------------------
+
+TEST_F(BaroThrustCfRlsTest, ResetClearsConvergence)
+{
+	_estimator.reset();
+
+	const float K_true = -3.f;
+	const float bias_true = 0.1f;
+
+	// Drive to convergence
+	for (float t = 0.f; t < 80.f; t += _dt) {
+		const float thrust = 0.5f + 0.15f * sinf(2.f * 3.14159f * t / 5.f);
+		const float residual = K_true * thrust + bias_true;
+		_estimator.updateEstimator(residual, thrust, _dt);
+		_estimator.checkConvergence(t, _dt);
+	}
+
+	EXPECT_TRUE(_estimator.convergedLocked());
+	EXPECT_NEAR(_estimator.kEstimate(), K_true, 0.2f);
+
+	// Reset should clear all convergence state
+	_estimator.reset();
+	EXPECT_FALSE(_estimator.converged());
+	EXPECT_FALSE(_estimator.convergedLocked());
+	EXPECT_NEAR(_estimator.kEstimate(), 0.f, 1e-6f);
+	EXPECT_NEAR(_estimator.kEstimateVar(), BaroThrustCfRls::RLS_P_INIT, 1e-6f);
+}
+
+// ---------------------------------------------------------------------------
+// Convergence gating
+// ---------------------------------------------------------------------------
+
+TEST_F(BaroThrustCfRlsTest, ConvergenceRequiresMinTime)
+{
+	_estimator.reset();
+
+	const float K_true = -3.f;
+
+	for (float t = 0.f; t < 25.f; t += _dt) { // < 30s minimum
+		const float thrust = 0.5f + 0.15f * sinf(2.f * 3.14159f * t / 5.f);
+		const float residual = K_true * thrust;
+		_estimator.updateEstimator(residual, thrust, _dt);
+		_estimator.checkConvergence(t, _dt);
+	}
+
+	EXPECT_FALSE(_estimator.convergedLocked());
+}
+
+TEST_F(BaroThrustCfRlsTest, ConvergenceLocksAfterHoldTime)
+{
+	_estimator.reset();
+
+	const float K_true = -3.f;
+	const float bias_true = 0.1f;
+
+	for (float t = 0.f; t < 80.f; t += _dt) {
+		const float thrust = 0.5f + 0.15f * sinf(2.f * 3.14159f * t / 5.f);
+		const float residual = K_true * thrust + bias_true;
+		_estimator.updateEstimator(residual, thrust, _dt);
+		_estimator.checkConvergence(t, _dt);
+	}
+
+	EXPECT_TRUE(_estimator.convergedLocked());
+	EXPECT_NEAR(_estimator.kEstimate(), K_true, 0.2f);
+}

--- a/src/modules/baro_thrust_estimator/baro_thrust_cf_rls_test.cpp
+++ b/src/modules/baro_thrust_estimator/baro_thrust_cf_rls_test.cpp
@@ -217,6 +217,22 @@ TEST_F(BaroThrustCfRlsTest, ConvergenceRequiresMinTime)
 	EXPECT_FALSE(_estimator.convergedLocked());
 }
 
+TEST_F(BaroThrustCfRlsTest, NoExcitationDoesNotConverge)
+{
+	_estimator.reset();
+
+	// Constant thrust — no excitation. RLS can fit K but the excitation
+	// gate should prevent convergence since we can't trust the estimate.
+	for (float t = 0.f; t < 80.f; t += _dt) {
+		const float thrust = 0.5f;
+		const float residual = -3.f * thrust;
+		_estimator.updateEstimator(residual, thrust, _dt);
+		_estimator.checkConvergence(t, _dt);
+	}
+
+	EXPECT_FALSE(_estimator.convergedLocked());
+}
+
 TEST_F(BaroThrustCfRlsTest, ConvergenceLocksAfterHoldTime)
 {
 	_estimator.reset();

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -82,6 +82,7 @@ void LoggedTopics::add_default_topics()
 	add_optional_topic_multi("heater_status");
 	add_topic("home_position");
 	add_topic("hover_thrust_estimate", 100);
+	add_topic("baro_thrust_estimate", 100);
 	add_topic("input_rc", 500);
 	add_optional_topic("internal_combustion_engine_control", 10);
 	add_optional_topic("internal_combustion_engine_status", 10);

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -124,7 +124,9 @@ float VehicleAirData::thrustCompensation(hrt_abstime timestamp_sample)
 		return 0.f;
 	}
 
-	// Find the thrust sample closest to the baro measurement time
+	// Find the thrust sample closest to the baro measurement time.
+	// Buffer is chronologically ordered (newest at head-1), so once
+	// the time delta starts increasing we've passed the closest match.
 	int best_idx = -1;
 	hrt_abstime best_dt = UINT64_MAX;
 
@@ -141,6 +143,9 @@ float VehicleAirData::thrustCompensation(hrt_abstime timestamp_sample)
 		if (dt < best_dt) {
 			best_dt = dt;
 			best_idx = idx;
+
+		} else {
+			break;
 		}
 	}
 

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.cpp
@@ -99,6 +99,58 @@ float VehicleAirData::AirTemperatureUpdate(const float temperature_baro, Tempera
 	return math::constrain(temperature, TEMPERATURE_MIN_CELSIUS, TEMPERATURE_MAX_CELSIUS);
 }
 
+void VehicleAirData::updateThrustBuffer()
+{
+	vehicle_thrust_setpoint_s thrust_sp;
+
+	while (_vehicle_thrust_setpoint_sub.update(&thrust_sp)) {
+		ThrustSample &sample = _thrust_buffer[_thrust_buffer_head];
+		sample.timestamp = thrust_sp.timestamp;
+		sample.thrust_z = PX4_ISFINITE(thrust_sp.xyz[2]) ? fabsf(thrust_sp.xyz[2]) : 0.f;
+
+		_thrust_buffer_head = (_thrust_buffer_head + 1) % THRUST_BUFFER_SIZE;
+
+		if (_thrust_buffer_count < THRUST_BUFFER_SIZE) {
+			_thrust_buffer_count++;
+		}
+	}
+}
+
+float VehicleAirData::thrustCompensation(hrt_abstime timestamp_sample)
+{
+	const float pcoef = _param_sens_baro_pcoef.get();
+
+	if (fabsf(pcoef) < FLT_EPSILON || _thrust_buffer_count == 0) {
+		return 0.f;
+	}
+
+	// Find the thrust sample closest to the baro measurement time
+	int best_idx = -1;
+	hrt_abstime best_dt = UINT64_MAX;
+
+	for (int i = 0; i < _thrust_buffer_count; i++) {
+		int idx = (_thrust_buffer_head - 1 - i + THRUST_BUFFER_SIZE) % THRUST_BUFFER_SIZE;
+		const hrt_abstime ts = _thrust_buffer[idx].timestamp;
+
+		if (ts == 0) {
+			continue;
+		}
+
+		const hrt_abstime dt = (ts >= timestamp_sample) ? (ts - timestamp_sample) : (timestamp_sample - ts);
+
+		if (dt < best_dt) {
+			best_dt = dt;
+			best_idx = idx;
+		}
+	}
+
+	if (best_idx < 0 || best_dt > 500_ms) {
+		return 0.f;
+	}
+
+	return pcoef * _thrust_buffer[best_idx].thrust_z;
+}
+
 bool VehicleAirData::ParametersUpdate(bool force)
 {
 	// Check if parameters have changed
@@ -143,6 +195,8 @@ void VehicleAirData::Run()
 	const hrt_abstime time_now_us = hrt_absolute_time();
 
 	const bool parameter_update = ParametersUpdate();
+
+	updateThrustBuffer();
 
 	estimator_status_flags_s estimator_status_flags;
 	const bool estimator_status_flags_updated = _estimator_status_flags_sub.update(&estimator_status_flags);
@@ -260,7 +314,7 @@ void VehicleAirData::Run()
 		if (!_relative_calibration_done) {
 			_relative_calibration_done = UpdateRelativeCalibrations(time_now_us);
 
-		} else if (!_baro_gnss_calibration_done && _param_sens_baro_autocal.get() && latest_estimator_status_flags.cs_gps_hgt) {
+		} else if (!_baro_gnss_calibration_done && (_param_sens_baro_autocal.get() & 1) && latest_estimator_status_flags.cs_gps_hgt) {
 			_baro_gnss_calibration_done = BaroGNSSAltitudeOffset();
 		}
 	}
@@ -292,7 +346,8 @@ void VehicleAirData::Run()
 						const float ambient_temperature = AirTemperatureUpdate(temperature_baro, temperature_source, time_now_us);
 
 						const float pressure_sealevel_pa = _param_sens_baro_qnh.get() * 100.f;
-						const float altitude = getAltitudeFromPressure(pressure_pa, pressure_sealevel_pa);
+						float altitude = getAltitudeFromPressure(pressure_pa, pressure_sealevel_pa);
+						altitude += thrustCompensation(timestamp_sample);
 
 						// calculate air density
 						const float air_density = getDensityFromPressureAndTemp(pressure_pa, ambient_temperature);

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -91,6 +91,10 @@ private:
 	bool UpdateRelativeCalibrations(hrt_abstime time_now_us);
 	bool BaroGNSSAltitudeOffset();
 
+	// Note: applies a single PCOEF to whichever baro the voter selects as primary.
+	// If baros are at different locations (e.g., internal vs external CAN), they may
+	// experience different propwash magnitudes — a per-instance PCOEF would be needed
+	// to handle that correctly. For now this assumes co-located sensors.
 	float thrustCompensation(hrt_abstime timestamp_sample);
 	void updateThrustBuffer();
 

--- a/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
+++ b/src/modules/sensors/vehicle_air_data/VehicleAirData.hpp
@@ -57,6 +57,7 @@
 #include <uORB/topics/vehicle_air_data.h>
 #include <uORB/topics/estimator_status_flags.h>
 #include <uORB/topics/sensor_gps.h>
+#include <uORB/topics/vehicle_thrust_setpoint.h>
 
 using namespace time_literals;
 
@@ -90,6 +91,20 @@ private:
 	bool UpdateRelativeCalibrations(hrt_abstime time_now_us);
 	bool BaroGNSSAltitudeOffset();
 
+	float thrustCompensation(hrt_abstime timestamp_sample);
+	void updateThrustBuffer();
+
+	static constexpr int THRUST_BUFFER_SIZE = 8;
+
+	struct ThrustSample {
+		hrt_abstime timestamp{0};
+		float thrust_z{0.f};
+	};
+
+	ThrustSample _thrust_buffer[THRUST_BUFFER_SIZE] {};
+	int _thrust_buffer_head{0};
+	int _thrust_buffer_count{0};
+
 	static constexpr int MAX_SENSOR_COUNT = 4;
 
 	uORB::Publication<sensors_status_s> _sensors_status_baro_pub{ORB_ID(sensors_status_baro)};
@@ -110,6 +125,8 @@ private:
 	};
 
 	uORB::Subscription _vehicle_gps_position_sub{ORB_ID(vehicle_gps_position)};
+
+	uORB::Subscription _vehicle_thrust_setpoint_sub{ORB_ID(vehicle_thrust_setpoint)};
 
 	calibration::Barometer _calibration[MAX_SENSOR_COUNT];
 
@@ -148,7 +165,8 @@ private:
 	DEFINE_PARAMETERS(
 		(ParamFloat<px4::params::SENS_BARO_QNH>) _param_sens_baro_qnh,
 		(ParamFloat<px4::params::SENS_BARO_RATE>) _param_sens_baro_rate,
-		(ParamBool<px4::params::SENS_BAR_AUTOCAL>) _param_sens_baro_autocal
+		(ParamInt<px4::params::SENS_BAR_AUTOCAL>) _param_sens_baro_autocal,
+		(ParamFloat<px4::params::SENS_BARO_PCOEF>) _param_sens_baro_pcoef
 	)
 };
 }; // namespace sensors

--- a/src/modules/sensors/vehicle_air_data/params.yaml
+++ b/src/modules/sensors/vehicle_air_data/params.yaml
@@ -24,7 +24,29 @@ parameters:
     SENS_BAR_AUTOCAL:
       description:
         short: Barometer auto calibration
-        long: Automatically calibrate barometer based on the GNSS height
+        long: |
+          Bitmask controlling automatic barometer calibrations.
+          Bit 0: GNSS-based altitude offset calibration.
+          Bit 1: Online thrust compensation estimation (identifies
+          SENS_BARO_PCOEF during flight and saves on disarm).
       category: System
-      type: boolean
+      type: bitmask
+      bit:
+        0: GNSS altitude offset
+        1: Thrust compensation
       default: 1
+      min: 0
+      max: 3
+    SENS_BARO_PCOEF:
+      description:
+        short: Baro altitude correction per unit vertical thrust
+        long: |-
+          Corrects propwash-induced baro error proportional to vertical
+          thrust setpoint magnitude. Sign depends on sensor placement
+          relative to propellers. Set to 0 to disable.
+      type: float
+      default: 0.0
+      min: -30.0
+      max: 30.0
+      unit: m
+      decimal: 1


### PR DESCRIPTION
## Summary

Add propwash-induced barometer error compensation. Propellers create static pressure changes at the baro sensor proportional to motor output. On the test vehicle (ARK FPV, BMP390), this causes ~7m altitude error correlated with thrust (r=0.91).

The correction model:
```
baro_alt += SENS_BARO_PCOEF * thrust_z
```

## Components

### Thrust compensation (`VehicleAirData`)
- Motor thrust ring buffer (8 samples) with time-matched lookup against baro `timestamp_sample`
- Param `SENS_BARO_PCOEF`: altitude correction per unit vertical thrust [m]
- `SENS_BAR_AUTOCAL` changed from boolean to bitmask (bit 0: GNSS cal, bit 1: thrust comp)

### Online estimator (`baro_thrust_estimator` module)
- Complementary filter (CF) isolates thrust-correlated baro error at 0.05 Hz crossover
- Recursive least squares (RLS) identifies gain K online
- Saves identified coefficient to `SENS_BARO_PCOEF` on disarm when converged
- Controlled by `SENS_BAR_AUTOCAL` bit 1 (started conditionally in `rc.mc_apps`)

### Analysis tools (`Tools/baro_compensation/`)
- `baro_thrust_calibration.py <log.ulg>` — offline calibration/validation with PDF output

## Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `SENS_BARO_PCOEF` | 0.0 | Baro alt correction per unit thrust [m] |
| `SENS_BAR_AUTOCAL` | 1 | Bitmask: bit 0 = GNSS cal, bit 1 = thrust comp |

## Test results (ARK FPV)

- K ≈ -20 to -22m consistent across flights, online/offline agree within 0.5m
- Compensation: thrust correlation r from 0.91 → 0.16, error std from 2.3m → 0.95m
- BMP390 integration window (37ms) smooths over motor response (~15ms), no delay param needed