### PR TITLE
fix(baro): correct timestamp_sample to integration midpoint across all baro drivers

### DIFF
--- a/src/drivers/barometer/bmp280/BMP280.cpp
+++ b/src/drivers/barometer/bmp280/BMP280.cpp
@@ -144,8 +144,12 @@ BMP280::collect()
 
 	_collect_phase = false;
 
-	// this should be fairly close to the end of the conversion, so the best approximation of the time
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	/* Correct for measurement integration delay: the pressure was
+	 * integrated over the preceding _measure_interval window, so the
+	 * effective sample midpoint is half the measurement time before now. */
+	const hrt_abstime now = hrt_absolute_time();
+	const hrt_abstime half_meas = _measure_interval / 2;
+	const hrt_abstime timestamp_sample = (now > half_meas) ? (now - half_meas) : now;
 	bmp280::data_s *data = _interface->get_data(BMP280_ADDR_DATA);
 
 	if (data == nullptr) {

--- a/src/drivers/barometer/bmp581/bmp581.cpp
+++ b/src/drivers/barometer/bmp581/bmp581.cpp
@@ -137,8 +137,12 @@ int BMP581::collect()
 
 	perf_begin(_sample_perf);
 
-	/* this should be fairly close to the end of the conversion, so the best approximation of the time */
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	/* Correct for measurement integration delay: the pressure was
+	 * integrated over the preceding measurement_time window, so the
+	 * effective sample midpoint is half the measurement time before now. */
+	const hrt_abstime now = hrt_absolute_time();
+	const hrt_abstime half_meas = get_measurement_time() / 2;
+	const hrt_abstime timestamp_sample = (now > half_meas) ? (now - half_meas) : now;
 
 	int_status = get_interrupt_status();
 

--- a/src/drivers/barometer/lps22hb/LPS22HB.cpp
+++ b/src/drivers/barometer/lps22hb/LPS22HB.cpp
@@ -139,8 +139,12 @@ int LPS22HB::collect()
 		uint8_t		TEMP_OUT_H;
 	} report{};
 
-	/* this should be fairly close to the end of the measurement, so the best approximation of the time */
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	/* Correct for measurement integration delay: the one-shot conversion
+	 * was started CONVERSION_INTERVAL ago, so the effective sample
+	 * midpoint is half the conversion interval before now. */
+	const hrt_abstime now = hrt_absolute_time();
+	const hrt_abstime half_meas = LPS22HB_CONVERSION_INTERVAL / 2;
+	const hrt_abstime timestamp_sample = (now > half_meas) ? (now - half_meas) : now;
 	int ret = _interface->read(STATUS, (uint8_t *)&report, sizeof(report));
 
 	if (ret != OK) {

--- a/src/drivers/barometer/lps25h/LPS25H.cpp
+++ b/src/drivers/barometer/lps25h/LPS25H.cpp
@@ -151,8 +151,12 @@ int LPS25H::collect()
 		int16_t		t;
 	} report{};
 
-	/* get measurements from the device : MSB enables register address auto-increment */
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	/* Correct for measurement integration delay: the one-shot conversion
+	 * was started CONVERSION_INTERVAL ago, so the effective sample
+	 * midpoint is half the conversion interval before now. */
+	const hrt_abstime now = hrt_absolute_time();
+	const hrt_abstime half_meas = LPS25H_CONVERSION_INTERVAL / 2;
+	const hrt_abstime timestamp_sample = (now > half_meas) ? (now - half_meas) : now;
 	int ret = _interface->read(ADDR_STATUS_REG | (1 << 7), (uint8_t *)&report, sizeof(report));
 
 	if (ret != OK) {

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.cpp
@@ -50,6 +50,7 @@
 
 #define MPL3115A2_CONVERSION_INTERVAL	10000	/* microseconds */
 #define MPL3115A2_OSR                   2       /* Over Sample rate of 4 18MS Minimum time between data samples */
+#define MPL3115A2_CONVERSION_TIME	18000	/* ADC conversion time at OSR 2 (ratio 4), microseconds */
 #define MPL3115A2_CTRL_TRIGGER          (CTRL_REG1_OST | CTRL_REG1_OS(MPL3115A2_OSR))
 
 MPL3115A2::MPL3115A2(const I2CSPIDriverConfig &config) :
@@ -191,6 +192,8 @@ int MPL3115A2::measure()
 {
 	perf_begin(_measure_perf);
 
+	_conversion_start = hrt_absolute_time();
+
 	// Send the command to read the ADC for P and T.
 	unsigned addr = (MPL3115A2_CTRL_REG1 << 8) | MPL3115A2_CTRL_TRIGGER;
 
@@ -228,7 +231,12 @@ int MPL3115A2::collect()
 	 */
 	uint8_t	b[3 + 2] {};
 	uint8_t reg = OUT_P_MSB;
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+
+	/* Correct for measurement integration delay: _conversion_start was
+	 * recorded when OST was triggered, so the effective sample midpoint
+	 * is start + half the conversion time.  This avoids polling-interval
+	 * jitter that would occur if we derived the midpoint from "now". */
+	const hrt_abstime timestamp_sample = _conversion_start + MPL3115A2_CONVERSION_TIME / 2;
 	ret = transfer(&reg, 1, &b[0], sizeof(b));
 
 	if (ret == -EIO) {

--- a/src/drivers/barometer/mpl3115a2/MPL3115A2.hpp
+++ b/src/drivers/barometer/mpl3115a2/MPL3115A2.hpp
@@ -80,6 +80,7 @@ private:
 	uORB::PublicationMulti<sensor_baro_s> _sensor_baro_pub{ORB_ID(sensor_baro)};
 
 	bool _collect_phase{false};
+	hrt_abstime _conversion_start{0};
 
 	perf_counter_t _sample_perf;
 	perf_counter_t _measure_perf;

--- a/src/drivers/barometer/ms5611/MS5611.hpp
+++ b/src/drivers/barometer/ms5611/MS5611.hpp
@@ -83,6 +83,7 @@ enum MS56XX_DEVICE_TYPES {
  * conversion finished
  */
 #define MS5611_CONVERSION_INTERVAL	10000	/* microseconds */
+#define MS5611_OSR1024_CONVERSION_TIME	2280	/* max ADC conversion time at OSR 1024 (see ADDR_CMD_CONVERT_D1_OSR1024), microseconds */
 #define MS5611_MEASUREMENT_RATIO	3	/* pressure measurements per temperature measurement */
 
 class MS5611 : public I2CSPIDriver<MS5611>

--- a/src/drivers/barometer/ms5611/ms5611.cpp
+++ b/src/drivers/barometer/ms5611/ms5611.cpp
@@ -243,8 +243,13 @@ MS5611::collect()
 
 	perf_begin(_sample_perf);
 
-	/* read the most recent measurement - read offset/size are hardcoded in the interface */
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	/* Correct for measurement integration delay: the conversion was
+	 * started CONVERSION_INTERVAL ago and took OSR1024_CONVERSION_TIME
+	 * to integrate, so the effective sample midpoint is
+	 * (CONVERSION_INTERVAL - OSR1024_CONVERSION_TIME/2) before now. */
+	const hrt_abstime now = hrt_absolute_time();
+	static constexpr hrt_abstime correction = MS5611_CONVERSION_INTERVAL - MS5611_OSR1024_CONVERSION_TIME / 2;
+	const hrt_abstime timestamp_sample = (now > correction) ? (now - correction) : now;
 	int ret = _interface->read(0, (void *)&raw, 0);
 
 	if (ret < 0) {

--- a/src/drivers/barometer/ms5837/MS5837.cpp
+++ b/src/drivers/barometer/ms5837/MS5837.cpp
@@ -269,8 +269,13 @@ int MS5837::_collect()
 
 	perf_begin(_sample_perf);
 
-	/* read the most recent measurement - read offset/size are hardcoded in the interface */
-	const hrt_abstime timestamp_sample = hrt_absolute_time();
+	/* Correct for measurement integration delay: the conversion was
+	 * started CONVERSION_INTERVAL ago and took OSR1024_CONVERSION_TIME
+	 * to integrate, so the effective sample midpoint is
+	 * (CONVERSION_INTERVAL - OSR1024_CONVERSION_TIME/2) before now. */
+	const hrt_abstime now = hrt_absolute_time();
+	static constexpr hrt_abstime correction = MS5837_CONVERSION_INTERVAL - MS5837_OSR1024_CONVERSION_TIME / 2;
+	const hrt_abstime timestamp_sample = (now > correction) ? (now - correction) : now;
 	int ret = read(0, (void *)&raw, 0);
 
 	if (ret < 0) {

--- a/src/drivers/barometer/ms5837/ms5837_registers.h
+++ b/src/drivers/barometer/ms5837/ms5837_registers.h
@@ -83,6 +83,7 @@
  * conversion finished
  */
 #define MS5837_CONVERSION_INTERVAL	10000	/* microseconds */
+#define MS5837_OSR1024_CONVERSION_TIME	2280	/* max ADC conversion time at OSR 1024 (see ADDR_CMD_CONVERT_D1_OSR1024), microseconds */
 #define MS5837_MEASUREMENT_RATIO	3	/* pressure measurements per temperature measurement */
 
 namespace ms5837


### PR DESCRIPTION
## Summary

- Correct `timestamp_sample` in 7 barometer drivers to reflect the integration midpoint rather than the SPI/I2C read time, eliminating a systematic timing bias equal to half the measurement window
- Companion to PX4/PX4-Autopilot#26920 (BMP388), which identified this class of bug — this PR applies the same fix to all other affected baro drivers
- Each driver is fixed in its own commit

## Drivers fixed

| Driver | Mode | Measurement Time | Correction |
|--------|------|-----------------|------------|
| BMP280 | Forced | ~43ms | `now - _measure_interval/2` |
| BMP581 | Normal | ~23ms | `now - get_measurement_time()/2` |
| MS5611 | Cmd-response | 2.28ms conv, 10ms delay | `now - (INTERVAL - CONV_TIME/2)` |
| MS5837 | Cmd-response | 2.28ms conv, 10ms delay | `now - (INTERVAL - CONV_TIME/2)` |
| LPS22HB | One-shot | ~40ms | `now - INTERVAL/2` |
| LPS25H | One-shot | ~40ms | `now - INTERVAL/2` |
| MPL3115A2 | One-shot (polled) | 18ms | `start_time + CONV_TIME/2` |

## Drivers not changed

DPS310, LPS33HW, SPL06, SPA06, ICP201XX, ICP101XX, MPC2520, TCBP001TA — these use continuous measurement mode where the internal integration timing is not explicitly exposed. They would need individual datasheet-level analysis.