### PR TITLE
uavcan: add PX4_INFO logging for firmware update lifecycle

### DIFF
--- a/src/drivers/uavcan/uavcan_drivers/posix/include/uavcan_posix/basic_file_server_backend.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/posix/include/uavcan_posix/basic_file_server_backend.hpp
@@ -27,6 +27,8 @@
 #include <uavcan/protocol/file_server.hpp>
 #include <uavcan/data_type.hpp>
 
+#include <px4_platform_common/log.h>
+
 namespace uavcan_posix
 {
 /**
@@ -438,7 +440,20 @@ protected:
 					} while (nread > 0 && remaining > 0);
 				}
 
-				(void)cache.close(fd, rv != 0 || total_read != inout_size);
+				const bool done = rv != 0 || total_read != (ssize_t)inout_size;
+
+				if (done) {
+					if (rv == 0) {
+						PX4_INFO("UAVCAN firmware update file transfer finished: %s",
+							 path.c_str());
+
+					} else {
+						PX4_WARN("UAVCAN firmware update file read error: %s rv=%d",
+							 path.c_str(), rv);
+					}
+				}
+
+				(void)cache.close(fd, done);
 				inout_size = total_read;
 			}
 		}

--- a/src/drivers/uavcan/uavcan_drivers/posix/include/uavcan_posix/firmware_version_checker.hpp
+++ b/src/drivers/uavcan/uavcan_drivers/posix/include/uavcan_posix/firmware_version_checker.hpp
@@ -18,6 +18,8 @@
 
 #include <uavcan/protocol/firmware_update_trigger.hpp>
 
+#include <px4_platform_common/log.h>
+
 // TODO Get rid of the macro
 #if !defined(DIRENT_ISFILE) && defined(DT_REG)
 # define DIRENT_ISFILE(dtype)  ((dtype) == DT_REG)
@@ -94,7 +96,7 @@ protected:
 	 * @return                          True - the class will begin sending update requests.
 	 *                                  False - the node will be ignored, no request will be sent.
 	 */
-	virtual bool shouldRequestFirmwareUpdate(uavcan::NodeID,
+	virtual bool shouldRequestFirmwareUpdate(uavcan::NodeID node_id,
 			const uavcan::protocol::GetNodeInfo::Response &node_info,
 			FirmwareFilePath &out_firmware_file_path)
 	{
@@ -141,6 +143,8 @@ protected:
 				      descriptor.image_crc != node_info.software_version.image_crc)) {
 				rv = true;
 				out_firmware_file_path = bin_file_name;
+				PX4_INFO("UAVCAN firmware update needed: node %d, board 0x%04x, file %s",
+					 int(node_id.get()), board_id, bin_file_name);
 			}
 		}
 
@@ -166,12 +170,27 @@ protected:
 	 * @return                          True - the class will continue sending update requests with new firmware path.
 	 *                                  False - the node will be forgotten, new requests will not be sent.
 	 */
-	virtual bool shouldRetryFirmwareUpdate(uavcan::NodeID,
-					       const uavcan::protocol::file::BeginFirmwareUpdate::Response &,
+	virtual bool shouldRetryFirmwareUpdate(uavcan::NodeID node_id,
+					       const uavcan::protocol::file::BeginFirmwareUpdate::Response &error_response,
 					       FirmwareFilePath &)
 	{
+		PX4_WARN("UAVCAN firmware update rejected by node %d: error=%d \"%s\" (retrying)",
+			 int(node_id.get()), int(error_response.error),
+			 error_response.optional_error_message.c_str());
 		// TODO: Limit the number of attempts per node
 		return true;
+	}
+
+	/**
+	 * Invoked when a node confirms (ERROR_OK or ERROR_IN_PROGRESS) a BeginFirmwareUpdate
+	 * request. This is the point at which the target node has accepted the request and
+	 * will begin pulling the image via uavcan.protocol.file.Read.
+	 */
+	virtual void handleFirmwareUpdateConfirmation(uavcan::NodeID node_id,
+			const uavcan::protocol::file::BeginFirmwareUpdate::Response &response)
+	{
+		PX4_INFO("UAVCAN firmware update started on node %d (response error=%d)",
+			 int(node_id.get()), int(response.error));
 	}
 
 public:


### PR DESCRIPTION
## Summary

- Surface DroneCAN node firmware update events on the NSH console.
- Previously only `UAVCAN_TRACE` (compiled out in normal builds) fired in this path, so there was no visible signal that an update had started, succeeded, or failed.

## Code

| Event | Severity | Chokepoint | Fires when |
|---|---|---|---|
| Update needed | `PX4_INFO` | `FirmwareVersionChecker::shouldRequestFirmwareUpdate` | PX4 finds a matching `<board_id>.bin` on disk with CRC differing from the running image |
| Update started | `PX4_INFO` | `FirmwareVersionChecker::handleFirmwareUpdateConfirmation` (new override) | Node responds to `BeginFirmwareUpdate` with `ERROR_OK` or `ERROR_IN_PROGRESS` |
| Update rejected | `PX4_WARN` | `FirmwareVersionChecker::shouldRetryFirmwareUpdate` | Node responds to `BeginFirmwareUpdate` with any other error (retry behaviour unchanged; still returns `true`) |
| Transfer finished | `PX4_INFO` | `BasicFileServerBackend::read` | Backend closes the image after a short read (EOF) |
| Transfer error | `PX4_WARN` | `BasicFileServerBackend::read` | `::read()` returns a non-zero errno while serving chunks |

The first three events include the target node ID. The file-server events carry the image path only — the `IFileServerBackend::read` API does not expose the requesting node ID.

## Follow-ups (not in this PR)

- Rate-limit the `shouldRetryFirmwareUpdate` warning (today it can fire every request-interval, ~1 Hz, until the node accepts or goes offline).
- Thread the requesting node ID through `IFileServerBackend::read` so transfer finish / error logs can name the node.