### PR TITLE
fix(flashparams): compact the param sector at boot instead of at the disarm-edge save

### DIFF
--- a/boards/ark/fpv/src/board_config.h
+++ b/boards/ark/fpv/src/board_config.h
@@ -262,6 +262,10 @@
 
 #define FLASH_BASED_PARAMS
 
+/* Bench jitter instrumentation marker on the FMU_CH8 pad (TIM8_CH4, untouched by DShot when
+ * only channels 1-4 carry motors) — see px4_platform_common/jitter_marker.h */
+#define BOARD_JITTER_MARKER_GPIO  /* PI2 */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTI|GPIO_PIN2)
+
 /* High-resolution timer */
 #define HRT_TIMER               3  /* use timer3 for the HRT */
 #define HRT_TIMER_CHANNEL       1 /* use capture/compare channel 1 */

--- a/boards/ark/fpv/src/board_config.h
+++ b/boards/ark/fpv/src/board_config.h
@@ -262,9 +262,10 @@
 
 #define FLASH_BASED_PARAMS
 
-/* Bench jitter instrumentation marker on the FMU_CH8 pad (TIM8_CH4, untouched by DShot when
- * only channels 1-4 carry motors) — see px4_platform_common/jitter_marker.h */
-#define BOARD_JITTER_MARKER_GPIO  /* PI2 */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTI|GPIO_PIN2)
+/* Bench jitter instrumentation marker on the FMU_CH4 pad (TIM5_CH1; an output channel DShot
+ * never claims when only channels 1-3 carry motors stays plain GPIO) — the ARK FPV fixture
+ * wires only M1-M4 to the logic analyzer. See px4_platform_common/jitter_marker.h */
+#define BOARD_JITTER_MARKER_GPIO  /* PH10 */ (GPIO_OUTPUT|GPIO_PUSHPULL|GPIO_SPEED_50MHz|GPIO_OUTPUT_CLEAR|GPIO_PORTH|GPIO_PIN10)
 
 /* High-resolution timer */
 #define HRT_TIMER               3  /* use timer3 for the HRT */

--- a/boards/ark/fpv/src/init.c
+++ b/boards/ark/fpv/src/init.c
@@ -225,6 +225,11 @@ __EXPORT int board_app_initialize(uintptr_t arg)
 
 	stm32_spiinitialize();
 
+#if defined(BOARD_JITTER_MARKER_GPIO)
+	/* Before flashfs init so a boot-time param sector compaction shows on the marker pad */
+	px4_arch_configgpio(BOARD_JITTER_MARKER_GPIO);
+#endif
+
 #if defined(FLASH_BASED_PARAMS)
 	static sector_descriptor_t params_sector_map[] = {
 		{15, 128 * 1024, 0x081E0000},

--- a/platforms/common/include/px4_platform_common/jitter_marker.h
+++ b/platforms/common/include/px4_platform_common/jitter_marker.h
@@ -1,0 +1,43 @@
+/****************************************************************************
+ * Bench-only jitter instrumentation.
+ *
+ * Emits a short pulse burst on a spare FMU pad so a logic analyzer capturing
+ * the DShot outputs can attribute output gaps to the responsible code path.
+ * Compiles to a no-op unless the board defines BOARD_JITTER_MARKER_GPIO
+ * (see boards/ark/fpv/src/board_config.h).
+ *
+ * Burst ids (number of pulses):
+ *   2 = arm transition          (Commander::arm success)
+ *   3 = disarm transition       (Commander::disarm success)
+ *   4 = param flash save start  (param_save_default, flash backend)
+ *   5 = param flash save end
+ *   6 = param sector erase start (flashfs32 wrap: 128 KB bank-2 sector erase)
+ *   7 = param sector erase end
+ ****************************************************************************/
+
+#pragma once
+
+#if defined(__PX4_NUTTX)
+#include <px4_platform_common/px4_config.h>
+#endif
+
+#if defined(__PX4_NUTTX) && defined(BOARD_JITTER_MARKER_GPIO)
+
+#include <nuttx/arch.h>
+#include <px4_arch/micro_hal.h>
+
+static inline void jitter_marker_burst(int pulse_count)
+{
+	for (int i = 0; i < pulse_count; i++) {
+		px4_arch_gpiowrite(BOARD_JITTER_MARKER_GPIO, true);
+		up_udelay(5);
+		px4_arch_gpiowrite(BOARD_JITTER_MARKER_GPIO, false);
+		up_udelay(5);
+	}
+}
+
+#else
+
+static inline void jitter_marker_burst(int pulse_count) { (void)pulse_count; }
+
+#endif

--- a/platforms/common/include/px4_platform_common/jitter_marker.h
+++ b/platforms/common/include/px4_platform_common/jitter_marker.h
@@ -28,6 +28,15 @@
 
 static inline void jitter_marker_burst(int pulse_count)
 {
+	/* Re-assert the pad config: the boot-time setup can be overridden once the output
+	 * timers configure (per-translation-unit static — reconfiguring is idempotent). */
+	static bool configured = false;
+
+	if (!configured) {
+		px4_arch_configgpio(BOARD_JITTER_MARKER_GPIO);
+		configured = true;
+	}
+
 	for (int i = 0; i < pulse_count; i++) {
 		px4_arch_gpiowrite(BOARD_JITTER_MARKER_GPIO, true);
 		up_udelay(5);

--- a/src/drivers/dshot/DShot.cpp
+++ b/src/drivers/dshot/DShot.cpp
@@ -158,6 +158,28 @@ bool DShot::updateOutputs(float *outputs, unsigned num_outputs, unsigned num_con
 
 	up_dshot_trigger();
 
+	perf_count(_output_interval_perf);
+	const hrt_abstime trigger_timestamp = hrt_absolute_time();
+
+	if (_last_trigger_timestamp != 0) {
+		const uint32_t gap_us = trigger_timestamp - _last_trigger_timestamp;
+
+		if (gap_us > _output_gap_max_us) {
+			_output_gap_max_us = gap_us;
+			_output_gap_max_timestamp = trigger_timestamp;
+		}
+
+		if (gap_us > GAP_RECORD_THRESHOLD_US && _previous_output_gap_us < 20000) {
+			_output_gap_records[_output_gap_next] = {trigger_timestamp, gap_us};
+			_output_gap_next = (_output_gap_next + 1) % GAP_RECORD_COUNT;
+			_output_gap_total++;
+		}
+
+		_previous_output_gap_us = gap_us;
+	}
+
+	_last_trigger_timestamp = trigger_timestamp;
+
 	return true;
 }
 
@@ -1126,6 +1148,19 @@ int DShot::print_status()
 	for (int i = 0; i < DSHOT_MAX_MOTORS; i++) {
 		if (_motor_mask & (1 << i)) {
 			PX4_INFO("    Motor %d: %d poles", i + 1, get_pole_count(i));
+		}
+	}
+
+	print_spacer();
+	PX4_INFO("Output gaps (> %lu us fast->slow transitions): %lu total, max %lu us at t=%llu us",
+		 (unsigned long)GAP_RECORD_THRESHOLD_US, (unsigned long)_output_gap_total,
+		 (unsigned long)_output_gap_max_us, (unsigned long long)_output_gap_max_timestamp);
+
+	for (unsigned i = 0; i < GAP_RECORD_COUNT; i++) {
+		const OutputGapRecord &record = _output_gap_records[(_output_gap_next + i) % GAP_RECORD_COUNT];
+
+		if (record.timestamp != 0) {
+			PX4_INFO("  gap %8lu us ending at t=%llu us", (unsigned long)record.gap_us, (unsigned long long)record.timestamp);
 		}
 	}
 

--- a/src/drivers/dshot/DShot.h
+++ b/src/drivers/dshot/DShot.h
@@ -208,6 +208,25 @@ private:
 	perf_counter_t	_serial_telem_error_perf{perf_alloc(PC_COUNT, MODULE_NAME": serial telem error")};
 	perf_counter_t	_serial_telem_timeout_perf{perf_alloc(PC_COUNT, MODULE_NAME": serial telem timeout")};
 	perf_counter_t	_serial_telem_allsampled_perf{perf_alloc(PC_COUNT, MODULE_NAME": serial telem all sampled")};
+	perf_counter_t	_output_interval_perf{perf_alloc(PC_INTERVAL, MODULE_NAME": output interval")};
+
+	// Output-gap watchdog (bench jitter instrumentation): gaps between consecutive
+	// up_dshot_trigger() calls above the threshold are kept in a ring for `dshot status`.
+	// Only fast->slow transitions are recorded so a legitimately slow disarmed cadence
+	// (50 ms backup schedule) does not flush the interesting records.
+	static constexpr uint32_t GAP_RECORD_THRESHOLD_US = 2500;
+	static constexpr unsigned GAP_RECORD_COUNT = 32;
+	struct OutputGapRecord {
+		hrt_abstime timestamp;
+		uint32_t gap_us;
+	};
+	OutputGapRecord _output_gap_records[GAP_RECORD_COUNT] {};
+	unsigned _output_gap_next{0};
+	uint32_t _output_gap_total{0};
+	uint32_t _output_gap_max_us{0};
+	hrt_abstime _output_gap_max_timestamp{0};
+	uint32_t _previous_output_gap_us{0};
+	hrt_abstime _last_trigger_timestamp{0};
 
 	// Commands
 	struct DShotCommand {

--- a/src/lib/parameters/flashparams/flashfs.h
+++ b/src/lib/parameters/flashparams/flashfs.h
@@ -212,6 +212,22 @@ __EXPORT int parameter_flashfs_write(flash_file_token_t ft, uint8_t *buffer, siz
 __EXPORT int parameter_flashfs_erase(void);
 
 /****************************************************************************
+ * Name: parameter_flashfs_compact_if_full
+ *
+ * Description:
+ *   If the sector lacks room for another entry the size of the stored one,
+ *   rewrite it through the normal wrap path now (sector erase + rewrite).
+ *   Called at boot so the bus-stalling erase never lands on a later save.
+ *
+ * Returned value:
+ *   1 if a compaction was performed, 0 if there was enough space or nothing
+ *   is stored, or a negative errno.
+ *
+ ****************************************************************************/
+
+__EXPORT int parameter_flashfs_compact_if_full(void);
+
+/****************************************************************************
  * Name: parameter_flashfs_alloc
  *
  * Description:

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -1111,6 +1111,67 @@ int parameter_flashfs_erase(void)
 
 
 /****************************************************************************
+ * Name: parameter_flashfs_compact_if_full
+ *
+ * Description:
+ *   If the sector cannot take another entry the size of the one it holds
+ *   (plus margin for growth), rewrite that entry now through the normal
+ *   write path, which wraps and erases the sector. Doing this at boot means
+ *   the seconds-long erase — which hardware-stalls every read from the same
+ *   flash bank, silencing the DShot outputs long enough to trip the AM32
+ *   signal-loss reset — never lands on a later save. In-service saves stay
+ *   append-only (a few 32-byte row programs). If the blob outgrows the
+ *   margin between boots the old save-time wrap still covers it.
+ *
+ * Returned value:
+ *   1 if a compaction (sector erase + rewrite) was performed, 0 if there
+ *   was enough space or nothing is stored, or a negative errno.
+ *
+ ****************************************************************************/
+
+int parameter_flashfs_compact_if_full(void)
+{
+	if (sector_map == NULL) {
+		return -ENXIO;
+	}
+
+	flash_entry_header_t *pf = find_entry(parameters_token);
+
+	if (pf == NULL) {
+		return 0;
+	}
+
+	size_t data_length = entry_data_length(pf);
+	size_t entry_total = sizeof(flash_entry_header_t) + data_length + SizeMask;
+	size_t reserve = entry_total + 2048;
+
+	if (check_free_space_in_sector(pf, reserve) == NULL) {
+		return 0;
+	}
+
+	/* The entry data lives in the flash about to be erased: copy it out first. */
+
+	uint8_t *buffer;
+	size_t buffer_size = data_length;
+	int rv = parameter_flashfs_alloc(parameters_token, &buffer, &buffer_size);
+
+	if (rv != 0) {
+		return rv;
+	}
+
+	if (buffer_size < data_length) {
+		parameter_flashfs_free();
+		return -ENOMEM;
+	}
+
+	memcpy(buffer, entry_data(pf), data_length);
+	rv = parameter_flashfs_write(parameters_token, buffer, data_length);
+	parameter_flashfs_free();
+
+	return rv >= 0 ? 1 : rv;
+}
+
+/****************************************************************************
  * Name: parameter_flashfs_init
  *
  * Description:
@@ -1166,6 +1227,13 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 			rv = 0;
 		}
 
+	} else {
+		// Pay the sector-wrap erase here at boot, not on a save at the disarm edge.
+		int compacted = parameter_flashfs_compact_if_full();
+
+		if (compacted < 0) {
+			rv = compacted;
+		}
 	}
 
 	return rv;

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -58,6 +58,7 @@
 #include "flashfs.h"
 #include <nuttx/compiler.h>
 #include <nuttx/progmem.h>
+#include <px4_platform_common/jitter_marker.h>
 #include <board_config.h>
 
 #if defined(CONFIG_ARCH_HAVE_PROGMEM)
@@ -986,7 +987,9 @@ parameter_flashfs_write(flash_file_token_t token, uint8_t *buffer, size_t buf_si
 				pf = (flash_entry_header_t *) current_sector->address;
 
 				if (!blank_check(pf, total_size)) {
+					jitter_marker_burst(6);
 					rv = erase_sector(current_sector, pf);
+					jitter_marker_burst(7);
 				}
 			}//free_space_in_sector returned not-zero
 
@@ -1162,6 +1165,7 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 		if (rv > 0) {
 			rv = 0;
 		}
+
 	}
 
 	return rv;

--- a/src/lib/parameters/parameters.cpp
+++ b/src/lib/parameters/parameters.cpp
@@ -56,6 +56,7 @@
 #include <drivers/drv_hrt.h>
 #include <lib/perf/perf_counter.h>
 #include <px4_platform_common/px4_config.h>
+#include <px4_platform_common/jitter_marker.h>
 #include <px4_platform_common/atomic_bitset.h>
 #include <px4_platform_common/defines.h>
 #include <px4_platform_common/posix.h>
@@ -857,9 +858,13 @@ int param_save_default(bool blocking)
 		}
 
 	} else {
+		jitter_marker_burst(4);
+		const hrt_abstime flash_save_start = hrt_absolute_time();
 		perf_begin(param_export_perf);
 		res = flash_param_save(nullptr);
 		perf_end(param_export_perf);
+		jitter_marker_burst(5);
+		PX4_INFO("flash param save took %.1f ms", (double)hrt_elapsed_time(&flash_save_start) / 1000.0);
 	}
 
 	if (res != PX4_OK) {

--- a/src/modules/commander/Commander.cpp
+++ b/src/modules/commander/Commander.cpp
@@ -46,6 +46,7 @@
 #include "esc_calibration.h"
 #define DEFINE_GET_PX4_CUSTOM_MODE
 #include "px4_custom_mode.h"
+#include <px4_platform_common/jitter_marker.h>
 #include "ModeUtil/control_mode.hpp"
 #include "ModeUtil/conversions.hpp"
 #include <lib/modes/ui.hpp>
@@ -739,6 +740,8 @@ transition_result_t Commander::arm(arm_disarm_reason_t calling_reason, bool run_
 
 	_status_changed = true;
 
+	jitter_marker_burst(2);
+
 	return TRANSITION_CHANGED;
 }
 
@@ -795,6 +798,8 @@ transition_result_t Commander::disarm(arm_disarm_reason_t calling_reason, bool f
 	_param_com_flight_uuid.commit_no_notification();
 
 	_status_changed = true;
+
+	jitter_marker_burst(3);
 
 	return TRANSITION_CHANGED;
 }


### PR DESCRIPTION
## Summary
Boot-time compaction of the flash param sector, plus the DShot jitter instrumentation used to find and measure the stall it removes. Four commits: the instrumentation (output-gap ring + `PC_INTERVAL` on the dshot trigger, logic-analyzer marker bursts via `jitter_marker.h`, ark/fpv marker pad), the compaction fix, and two bench-found fixups (marker rerouted to the FMU_CH4 pad since the FPV fixture only wires M1-M4 to the analyzer; pad config reasserted at first use). For upstream this likely splits in two: the flashparams fix stands alone, the instrumentation is bench tooling.

Measured on the ARK FPV bench (Saleae on the motor pads): a sector-wrap erase during a disarm-triggered save silenced the armed 800 Hz DShot stream for 768.6 ms on this part (the H743 datasheet allows 1-2.2 s). With this branch, the same forced-save workload (110 saves across sessions with reboots) produced zero armed-time erases — the wrap ran inside a reboot window instead (erase markers +0.58 s to +1.35 s into boot) — and armed steady-state held 802.3 Hz with sigma = 10 us, p99.9 = 1281 us.

## Problem
On FLASH_BASED_PARAMS boards every armed-time param write is deferred to the disarm edge (autosave), and disarm itself always dirties `COM_FLIGHT_UUID`, so a flash save lands ~300 ms after every disarm. Saves append into a single 128 KB sector; when the append wraps, flashfs erases the whole sector inline. On dual-bank H7 parts whose firmware spans into the param bank (ark/fpv: ~780 KB of .text above 0x08100000), the erase hardware-stalls every same-bank fetch for its full duration regardless of priority — `wq:rate_ctrl` at 255 included. The DShot outputs go silent, and AM32 ESCs hard-reset after 0.5 s of missing signal while armed (`faults.c`), matching the field report of ESCs rebooting at disarm every few dozen flights. An explicit `param save` while armed bypasses the deferral entirely, so the same stall can land in flight.

## Solution
`parameter_flashfs_compact_if_full()` in flashfs32.c, called from `parameter_flashfs_init()`: if the sector cannot take another entry of the stored size plus margin, rewrite the current entry through the existing wrap path at boot — the erase happens while the ESCs are disarmed and already expect signal loss, and every in-service save stays an append (measured 0.3-72 ms, invisible on the wire). If the blob outgrows the margin between boots, the old save-time wrap still covers correctness. The instrumentation commits add an output-gap ring to `dshot status` (fast-to-slow transitions with timestamps — note it undercounted the stall to 47.7 ms while the wire showed 768.6 ms, since the driver is itself stalled), a PC_INTERVAL perf counter on the output trigger, and pulse-burst markers (arm/disarm/save/erase) on a board-defined spare pad; everything is a no-op unless the board defines `BOARD_JITTER_MARKER_GPIO`.