### PR TITLE
fix(flashparams): compact the param sector at boot instead of at the disarm-edge save

### DIFF
--- a/src/lib/parameters/flashparams/flashfs.h
+++ b/src/lib/parameters/flashparams/flashfs.h
@@ -212,6 +212,22 @@ __EXPORT int parameter_flashfs_write(flash_file_token_t ft, uint8_t *buffer, siz
 __EXPORT int parameter_flashfs_erase(void);
 
 /****************************************************************************
+ * Name: parameter_flashfs_compact_if_full
+ *
+ * Description:
+ *   If the sector lacks room for another entry the size of the stored one,
+ *   rewrite it through the normal wrap path now (sector erase + rewrite).
+ *   Called at boot so the bus-stalling erase never lands on a later save.
+ *
+ * Returned value:
+ *   1 if a compaction was performed, 0 if there was enough space or nothing
+ *   is stored, or a negative errno.
+ *
+ ****************************************************************************/
+
+__EXPORT int parameter_flashfs_compact_if_full(void);
+
+/****************************************************************************
  * Name: parameter_flashfs_alloc
  *
  * Description:

--- a/src/lib/parameters/flashparams/flashfs32.c
+++ b/src/lib/parameters/flashparams/flashfs32.c
@@ -1108,6 +1108,67 @@ int parameter_flashfs_erase(void)
 
 
 /****************************************************************************
+ * Name: parameter_flashfs_compact_if_full
+ *
+ * Description:
+ *   If the sector cannot take another entry the size of the one it holds
+ *   (plus margin for growth), rewrite that entry now through the normal
+ *   write path, which wraps and erases the sector. Doing this at boot means
+ *   the seconds-long erase — which hardware-stalls every read from the same
+ *   flash bank, silencing the DShot outputs long enough to trip the AM32
+ *   signal-loss reset — never lands on a later save. In-service saves stay
+ *   append-only (a few 32-byte row programs). If the blob outgrows the
+ *   margin between boots the old save-time wrap still covers it.
+ *
+ * Returned value:
+ *   1 if a compaction (sector erase + rewrite) was performed, 0 if there
+ *   was enough space or nothing is stored, or a negative errno.
+ *
+ ****************************************************************************/
+
+int parameter_flashfs_compact_if_full(void)
+{
+	if (sector_map == NULL) {
+		return -ENXIO;
+	}
+
+	flash_entry_header_t *pf = find_entry(parameters_token);
+
+	if (pf == NULL) {
+		return 0;
+	}
+
+	size_t data_length = entry_data_length(pf);
+	size_t entry_total = sizeof(flash_entry_header_t) + data_length + SizeMask;
+	size_t reserve = entry_total + 2048;
+
+	if (check_free_space_in_sector(pf, reserve) == NULL) {
+		return 0;
+	}
+
+	/* The entry data lives in the flash about to be erased: copy it out first. */
+
+	uint8_t *buffer;
+	size_t buffer_size = data_length;
+	int rv = parameter_flashfs_alloc(parameters_token, &buffer, &buffer_size);
+
+	if (rv != 0) {
+		return rv;
+	}
+
+	if (buffer_size < data_length) {
+		parameter_flashfs_free();
+		return -ENOMEM;
+	}
+
+	memcpy(buffer, entry_data(pf), data_length);
+	rv = parameter_flashfs_write(parameters_token, buffer, data_length);
+	parameter_flashfs_free();
+
+	return rv >= 0 ? 1 : rv;
+}
+
+/****************************************************************************
  * Name: parameter_flashfs_init
  *
  * Description:
@@ -1161,6 +1222,14 @@ int parameter_flashfs_init(sector_descriptor_t *fconfig, uint8_t *buffer, uint16
 		// A positive return value means flash space has been erased successfully.
 		if (rv > 0) {
 			rv = 0;
+		}
+
+	} else {
+		// Pay the sector-wrap erase here at boot, not on a save at the disarm edge.
+		int compacted = parameter_flashfs_compact_if_full();
+
+		if (compacted < 0) {
+			rv = compacted;
 		}
 	}
 


### PR DESCRIPTION
## Summary
Pay the flash param sector's wrap erase at boot instead of during the save that lands right after disarm. Measured on the ARK FPV bench with a logic analyzer on the motor pads: the disarm-edge wrap erase silenced the armed 800 Hz DShot stream for 768.6 ms on this part (the H743 datasheet allows 1-2.2 s); with this fix the same forced-save workload (110 saves across sessions with reboots) produced zero armed-time erases — the wrap ran inside a reboot window instead — and every in-service save stayed a wire-invisible append.

## Problem
On FLASH_BASED_PARAMS boards every armed-time param write is deferred to the disarm edge (autosave), and disarm itself always dirties `COM_FLIGHT_UUID`, so a flash save lands ~300 ms after every disarm. Saves append into a single 128 KB sector; when the append wraps, flashfs erases the whole sector inline. On dual-bank H7 parts whose firmware spans into the param bank (ark/fpv: ~780 KB of .text above 0x08100000), the erase hardware-stalls every same-bank fetch for its full duration regardless of priority — `wq:rate_ctrl` at 255 included. The DShot outputs go silent, and AM32 ESCs hard-reset after 0.5 s of missing signal while armed (`faults.c`), matching field reports of ESCs rebooting at disarm every few dozen flights. An explicit `param save` while armed bypasses the deferral entirely, so the same stall can land in flight.

## Solution
`parameter_flashfs_compact_if_full()` in flashfs32.c, called from `parameter_flashfs_init()`: if the sector cannot take another entry of the stored size plus margin, rewrite the current entry through the existing wrap path at boot — the erase happens while the ESCs are disarmed and already expect signal loss. In-service saves stay appends (measured 0.3-72 ms). If the blob outgrows the margin between boots, the old save-time wrap still covers correctness.